### PR TITLE
Fix days filter default to constant

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,7 +51,7 @@ function downloadBlob(data, fileName, mimeType) {
 export default function App() {
   // State
   const [data, setData] = useState([]);
-  const [daysFilter, setDaysFilter] = useState(9);
+  const [daysFilter, setDaysFilter] = useState(DEFAULT_SPAN_DAYS);
   const [startDate, setStartDate] = useState(DateTime.local().toISODate());
   const [endDate, setEndDate] = useState(DateTime.local().plus({ days: daysFilter }).toISODate());
   const [statuses, setStatuses] = useState([]);


### PR DESCRIPTION
## Summary
- set `daysFilter` state to use `DEFAULT_SPAN_DAYS` constant

## Testing
- `npm run build` *(fails: esbuild binary for darwin arm64)*

------
https://chatgpt.com/codex/tasks/task_e_687bd2fc75708326a315ce9eac82598f