### PR TITLE
Fix upload screen on Safari

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -364,6 +364,22 @@ button.primary:hover {
   border-radius: var(--radius);
   cursor: pointer;
   transition: background 0.15s ease;
+  font: inherit;
+}
+
+/* Safari fallback */
+.container > input[type="file"]::-webkit-file-upload-button {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 0.15s ease;
+  font: inherit;
+}
+.container > input[type="file"]::-webkit-file-upload-button:hover {
+  background: var(--primary-dim);
 }
 
 .container > input[type="file"]::file-selector-button:hover {


### PR DESCRIPTION
## Summary
- improve file input styling with a Safari-specific rule

## Testing
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687bd954ceb88326984fa9ffe1abd55f