### PR TITLE
Add preview modal on downloads except ICS

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,46 +1,52 @@
-import React, { useState, useRef, useEffect } from 'react';
-import Papa from 'papaparse';
-import { DateTime } from 'luxon';
-import { v4 as uuidv4 } from 'uuid';
-import { createEvents } from 'ics';
+import React, { useState, useRef, useEffect } from "react";
+import Papa from "papaparse";
+import { DateTime } from "luxon";
+import { v4 as uuidv4 } from "uuid";
+import { createEvents } from "ics";
 // import domtoimage from 'dom-to-image';
-import html2canvas from 'html2canvas';
+import html2canvas from "html2canvas";
 
-const TODAY = DateTime.local().toISODate();           // 例: "2025-07-19"
-const DEFAULT_SPAN_DAYS = 7;                          // 期間
+const TODAY = DateTime.local().toISODate(); // 例: "2025-07-19"
+const DEFAULT_SPAN_DAYS = 7; // 期間
 
 function useDefaultFilters() {
-  const [days,       setDays]       = useState(DEFAULT_SPAN_DAYS);
-  const [startDate,  setStartDate]  = useState(TODAY);
-  const [endDate,    setEndDate]    = useState(
+  const [days, setDays] = useState(DEFAULT_SPAN_DAYS);
+  const [startDate, setStartDate] = useState(TODAY);
+  const [endDate, setEndDate] = useState(
     DateTime.local().plus({ days: DEFAULT_SPAN_DAYS }).toISODate(),
   );
-  const [keyword,    setKeyword]    = useState("");
-  const [statusOpt,  setStatusOpt]  = useState([]);
+  const [keyword, setKeyword] = useState("");
+  const [statusOpt, setStatusOpt] = useState([]);
 
   /** 条件をデフォルトへ戻す */
   const resetFilters = () => {
     setDays(DEFAULT_SPAN_DAYS);
     setStartDate(TODAY);
-    setEndDate(DateTime.local()
-      .plus({ days: DEFAULT_SPAN_DAYS })
-      .toISODate());
+    setEndDate(DateTime.local().plus({ days: DEFAULT_SPAN_DAYS }).toISODate());
     setKeyword("");
     setStatusOpt([]);
   };
 
   return {
-    days, startDate, endDate, keyword, statusOpt,
-    setDays, setStartDate, setEndDate, setKeyword, setStatusOpt,
+    days,
+    startDate,
+    endDate,
+    keyword,
+    statusOpt,
+    setDays,
+    setStartDate,
+    setEndDate,
+    setKeyword,
+    setStatusOpt,
     resetFilters,
   };
 }
 
 function downloadBlob(data, fileName, mimeType) {
   const blob = new Blob([data], { type: mimeType });
-  const url  = URL.createObjectURL(blob);
-  const a    = document.createElement('a');
-  a.href     = url;
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
   a.download = fileName;
   document.body.appendChild(a);
   a.click();
@@ -53,13 +59,17 @@ export default function App() {
   const [data, setData] = useState([]);
   const [daysFilter, setDaysFilter] = useState(DEFAULT_SPAN_DAYS);
   const [startDate, setStartDate] = useState(DateTime.local().toISODate());
-  const [endDate, setEndDate] = useState(DateTime.local().plus({ days: daysFilter }).toISODate());
+  const [endDate, setEndDate] = useState(
+    DateTime.local().plus({ days: daysFilter }).toISODate(),
+  );
   const [statuses, setStatuses] = useState([]);
-  const [keyword, setKeyword] = useState('');
+  const [keyword, setKeyword] = useState("");
 
   // Filter accordion open state (desktop open by default)
-  const [isFilterOpen, setIsFilterOpen] = useState(() =>
-    typeof window !== 'undefined' && window.matchMedia('(min-width: 768px)').matches
+  const [isFilterOpen, setIsFilterOpen] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(min-width: 768px)").matches,
   );
 
   // ファイル入力要素をクリアするための ref
@@ -79,13 +89,13 @@ export default function App() {
   // マウント時に常に sessionStorage から状態を復元
   useEffect(() => {
     const restore = () => {
-      const stored = sessionStorage.getItem('webclass-todo');
+      const stored = sessionStorage.getItem("webclass-todo");
       if (!stored) return;
       try {
         const { data: raw, filters } = JSON.parse(stored);
-        const parsed = raw.map(r => ({
+        const parsed = raw.map((r) => ({
           ...r,
-          締切: DateTime.fromISO(r.締切, { zone: 'Asia/Tokyo' })
+          締切: DateTime.fromISO(r.締切, { zone: "Asia/Tokyo" }),
         }));
         setData(parsed);
         setDaysFilter(filters.days);
@@ -94,17 +104,17 @@ export default function App() {
         setStatuses(filters.statuses);
         setKeyword(filters.keyword);
       } catch (e) {
-        console.error('State restore failed:', e);
+        console.error("State restore failed:", e);
       }
     };
 
     // 初回マウント
     restore();
     // 「戻る」で bfcache から復帰したときにも呼ぶ
-    window.addEventListener('pageshow', restore);
+    window.addEventListener("pageshow", restore);
 
     return () => {
-      window.removeEventListener('pageshow', restore);
+      window.removeEventListener("pageshow", restore);
     };
   }, []);
 
@@ -112,10 +122,15 @@ export default function App() {
   useEffect(() => {
     if (!data.length) return;
     const toStore = {
-      data: data.map(r => ({ 締切: r.締切.toISO(), 教材: r.教材, コース名: r.コース名, 状態: r.状態 })),
-      filters: { days: daysFilter, startDate, endDate, statuses, keyword }
+      data: data.map((r) => ({
+        締切: r.締切.toISO(),
+        教材: r.教材,
+        コース名: r.コース名,
+        状態: r.状態,
+      })),
+      filters: { days: daysFilter, startDate, endDate, statuses, keyword },
     };
-    sessionStorage.setItem('webclass-todo', JSON.stringify(toStore));
+    sessionStorage.setItem("webclass-todo", JSON.stringify(toStore));
   }, [data, daysFilter, startDate, endDate, statuses, keyword]);
 
   // File upload parsing
@@ -125,72 +140,100 @@ export default function App() {
     const reader = new FileReader();
     reader.onload = ({ target }) => {
       const lines = target.result.split(/\r?\n/);
-      const idx = lines.findIndex(l => l.startsWith('"学部","学科","コース名","教材","締切"'));
+      const idx = lines.findIndex((l) =>
+        l.startsWith('"学部","学科","コース名","教材","締切"'),
+      );
       if (idx < 0) {
-        alert('ヘッダー行が見つかりません');
+        alert("ヘッダー行が見つかりません");
         return;
       }
-      const csvText = lines.slice(idx).join('\n');
+      const csvText = lines.slice(idx).join("\n");
       Papa.parse(csvText, {
         header: true,
         skipEmptyLines: true,
         complete: ({ data: rows, meta }) => {
           const map = {
-            締切: ['締切','締切日','期限'],
-            教材: ['教材','課題','タイトル'],
-            コース名: ['コース名','科目名','講義名'],
-            状態: ['状態','ステータス','提出状況']
+            締切: ["締切", "締切日", "期限"],
+            教材: ["教材", "課題", "タイトル"],
+            コース名: ["コース名", "科目名", "講義名"],
+            状態: ["状態", "ステータス", "提出状況"],
           };
           const fieldMap = {};
           Object.entries(map).forEach(([key, aliases]) => {
-            const found = meta.fields.find(f => aliases.includes(f));
+            const found = meta.fields.find((f) => aliases.includes(f));
             if (found) fieldMap[key] = found;
           });
-          const missing = Object.keys(map).filter(k => !fieldMap[k]);
+          const missing = Object.keys(map).filter((k) => !fieldMap[k]);
           if (missing.length) {
-            alert(`列が見つかりません: ${missing.join(', ')}`);
+            alert(`列が見つかりません: ${missing.join(", ")}`);
             return;
           }
-          const parsed = rows.map(r => {
-            let dt = DateTime.fromISO(r[fieldMap['締切']], { zone: 'Asia/Tokyo' });
-            if (!dt.isValid) dt = DateTime.fromFormat(r[fieldMap['締切']], 'yyyy-MM-dd HH:mm', { zone: 'Asia/Tokyo' });
-            return { 締切: dt, 教材: r[fieldMap['教材']]||'', コース名: r[fieldMap['コース名']]||'', 状態: r[fieldMap['状態']]||'' };
+          const parsed = rows.map((r) => {
+            let dt = DateTime.fromISO(r[fieldMap["締切"]], {
+              zone: "Asia/Tokyo",
+            });
+            if (!dt.isValid)
+              dt = DateTime.fromFormat(
+                r[fieldMap["締切"]],
+                "yyyy-MM-dd HH:mm",
+                { zone: "Asia/Tokyo" },
+              );
+            return {
+              締切: dt,
+              教材: r[fieldMap["教材"]] || "",
+              コース名: r[fieldMap["コース名"]] || "",
+              状態: r[fieldMap["状態"]] || "",
+            };
           });
           setData(parsed);
-        }
+        },
       });
     };
-    reader.readAsText(file, 'utf-8');
+    reader.readAsText(file, "utf-8");
   };
 
   // Filter
   const filtered = data
-    .filter(r => r.締切.isValid)
-    .filter(r => {
+    .filter((r) => r.締切.isValid)
+    .filter((r) => {
       const d = r.締切;
       const s = DateTime.fromISO(startDate);
       const e = DateTime.fromISO(endDate);
       return d >= s && d <= e;
     })
-    .filter(r => !statuses.length || statuses.includes(r.状態))
-    .filter(r => !keyword || r.教材.includes(keyword) || r.コース名.includes(keyword))
-    .sort((a,b) => a.締切 - b.締切);
+    .filter((r) => !statuses.length || statuses.includes(r.状態))
+    .filter(
+      (r) =>
+        !keyword || r.教材.includes(keyword) || r.コース名.includes(keyword),
+    )
+    .sort((a, b) => a.締切 - b.締切);
 
   // Utils
   const saveFile = (blob, name) => {
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a'); a.href = url; a.download = name;
-    document.body.appendChild(a); a.click(); document.body.removeChild(a);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = name;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
     URL.revokeObjectURL(url);
   };
 
   const openPreview = (blob, name, mime) => {
-    const url = URL.createObjectURL(blob);
-    setPreview({ url, name, mime, blob });
+    if (mime === "text/csv") {
+      blob.text().then((text) => {
+        const { data: rows } = Papa.parse(text.trim());
+        setPreview({ name, mime, blob, rows });
+      });
+    } else {
+      const url = URL.createObjectURL(blob);
+      setPreview({ url, name, mime, blob });
+    }
   };
 
   const closePreview = () => {
-    if (preview) URL.revokeObjectURL(preview.url);
+    if (preview?.url) URL.revokeObjectURL(preview.url);
     setPreview(null);
   };
 
@@ -202,75 +245,94 @@ export default function App() {
   };
 
   const exportCSV = () => {
-    const csv = Papa.unparse(filtered, { columns: ['締切','教材','コース名','状態'] });
-    const blob = new Blob([csv], { type: 'text/csv' });
-    openPreview(blob, 'todo_filtered.csv', 'text/csv');
+    const csv = Papa.unparse(filtered, {
+      columns: ["締切", "教材", "コース名", "状態"],
+    });
+    const blob = new Blob([csv], { type: "text/csv" });
+    openPreview(blob, "todo_filtered.csv", "text/csv");
   };
 
   const exportICS = () => {
     if (!filtered.length) return;
     const lines = [
-      'BEGIN:VCALENDAR','VERSION:2.0','PRODID:-//WebClass ToDo//JP','CALSCALE:GREGORIAN',
-      'X-WR-TIMEZONE:Asia/Tokyo','BEGIN:VTIMEZONE','TZID:Asia/Tokyo','BEGIN:STANDARD',
-      'TZOFFSETFROM:+0900','TZOFFSETTO:+0900','TZNAME:JST','DTSTART:19700101T000000','END:STANDARD','END:VTIMEZONE'
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//WebClass ToDo//JP",
+      "CALSCALE:GREGORIAN",
+      "X-WR-TIMEZONE:Asia/Tokyo",
+      "BEGIN:VTIMEZONE",
+      "TZID:Asia/Tokyo",
+      "BEGIN:STANDARD",
+      "TZOFFSETFROM:+0900",
+      "TZOFFSETTO:+0900",
+      "TZNAME:JST",
+      "DTSTART:19700101T000000",
+      "END:STANDARD",
+      "END:VTIMEZONE",
     ];
     const now = DateTime.utc().toFormat("yyyyMMdd'T'HHmmss'Z'");
-    filtered.forEach(r => {
-      const dt = r.締切.setZone('Asia/Tokyo');
+    filtered.forEach((r) => {
+      const dt = r.締切.setZone("Asia/Tokyo");
       const dtStr = dt.toFormat("yyyyMMdd'T'HHmmss");
       lines.push(
-        'BEGIN:VEVENT',
+        "BEGIN:VEVENT",
         `UID:${uuidv4()}@webclass`,
         `DTSTAMP:${now}`,
         `DTSTART;TZID=Asia/Tokyo:${dtStr}`,
         `SUMMARY:${r.教材} (${r.コース名})`,
-        'END:VEVENT'
+        "END:VEVENT",
       );
     });
-    lines.push('END:VCALENDAR');
-    downloadBlob(lines.join('\r\n'), 'webclass_todo.ics', 'text/calendar');
+    lines.push("END:VCALENDAR");
+    downloadBlob(lines.join("\r\n"), "webclass_todo.ics", "text/calendar");
   };
 
   const exportTodoist = () => {
-    const recs = filtered.map(r => ({ TYPE:'task', CONTENT:`${r.教材} (${r.コース名})`, DATE:r.締切.toFormat('yyyy-MM-dd HH:mm'), DATE_LANG:'ja', TIMEZONE:'Asia/Tokyo' }));
+    const recs = filtered.map((r) => ({
+      TYPE: "task",
+      CONTENT: `${r.教材} (${r.コース名})`,
+      DATE: r.締切.toFormat("yyyy-MM-dd HH:mm"),
+      DATE_LANG: "ja",
+      TIMEZONE: "Asia/Tokyo",
+    }));
     const csv = Papa.unparse(recs);
-    const blob = new Blob([csv], { type: 'text/csv' });
-    openPreview(blob, 'todoist_template.csv', 'text/csv');
+    const blob = new Blob([csv], { type: "text/csv" });
+    openPreview(blob, "todoist_template.csv", "text/csv");
   };
 
   const exportPNGList = () => {
     // Current theme colors
     const styles = getComputedStyle(document.documentElement);
-    const bg     = styles.getPropertyValue('--bg').trim() || '#ffffff';
-    const surface= styles.getPropertyValue('--surface').trim() || '#ffffff';
-    const border = styles.getPropertyValue('--border').trim() || '#ddd';
-    const text   = styles.getPropertyValue('--text').trim() || '#000';
+    const bg = styles.getPropertyValue("--bg").trim() || "#ffffff";
+    const surface = styles.getPropertyValue("--surface").trim() || "#ffffff";
+    const border = styles.getPropertyValue("--border").trim() || "#ddd";
+    const text = styles.getPropertyValue("--text").trim() || "#000";
 
     // 縦型: フィルタ済みデータから手動でカード要素を生成
-    let wrapper = document.createElement('div');
+    let wrapper = document.createElement("div");
     wrapper.style.backgroundColor = bg;
     wrapper.style.color = text;
-    wrapper.style.padding = '1rem';
-    filtered.forEach(r => {
-      const card = document.createElement('div');
-      card.style.margin = '0.5rem 0';
-      card.style.padding = '0.75rem';
+    wrapper.style.padding = "1rem";
+    filtered.forEach((r) => {
+      const card = document.createElement("div");
+      card.style.margin = "0.5rem 0";
+      card.style.padding = "0.75rem";
       card.style.border = `1px solid ${border}`;
-      card.style.borderRadius = '4px';
+      card.style.borderRadius = "4px";
       card.style.background = surface;
       const fields = [
-        ['締切', r.締切.toFormat('yyyy-MM-dd HH:mm')],
-        ['教材', r.教材],
-        ['コース', r.コース名],
-        ['状態', r.状態]
+        ["締切", r.締切.toFormat("yyyy-MM-dd HH:mm")],
+        ["教材", r.教材],
+        ["コース", r.コース名],
+        ["状態", r.状態],
       ];
       fields.forEach(([label, value]) => {
-        const row = document.createElement('div');
-        row.style.marginBottom = '0.25rem';
-        const keyEl = document.createElement('span');
-        keyEl.style.fontWeight = 'bold';
+        const row = document.createElement("div");
+        row.style.marginBottom = "0.25rem";
+        const keyEl = document.createElement("span");
+        keyEl.style.fontWeight = "bold";
         keyEl.textContent = `${label}: `;
-        const valEl = document.createElement('span');
+        const valEl = document.createElement("span");
         valEl.textContent = value;
         row.appendChild(keyEl);
         row.appendChild(valEl);
@@ -279,57 +341,62 @@ export default function App() {
       wrapper.appendChild(card);
     });
     document.body.appendChild(wrapper);
-  html2canvas(wrapper, {
+    html2canvas(wrapper, {
       scale: 2,
       backgroundColor: bg,
       useCORS: true,
       width: wrapper.scrollWidth,
-      height: wrapper.scrollHeight
+      height: wrapper.scrollHeight,
     })
-      .then(canvas =>
-        canvas.toBlob(blob => openPreview(blob, 'webclass_todo_mobile.png', 'image/png'), 'image/png')
+      .then((canvas) =>
+        canvas.toBlob(
+          (blob) => openPreview(blob, "webclass_todo_mobile.png", "image/png"),
+          "image/png",
+        ),
       )
-      .catch(() => alert('webclass_todo_mobile.png の生成に失敗しました'))
+      .catch(() => alert("webclass_todo_mobile.png の生成に失敗しました"))
       .finally(() => {
         if (wrapper) document.body.removeChild(wrapper);
       });
   };
 
   const exportPNGTable = (isMobile) => {
-    const name = isMobile ? 'webclass_todo_mobile.png' : 'webclass_todo_table.png';
+    const name = isMobile
+      ? "webclass_todo_mobile.png"
+      : "webclass_todo_table.png";
     const styles = getComputedStyle(document.documentElement);
-    const bg     = styles.getPropertyValue('--bg').trim() || '#ffffff';
-    const surface= styles.getPropertyValue('--surface').trim() || '#ffffff';
-    const border = styles.getPropertyValue('--border').trim() || '#ddd';
-    const text   = styles.getPropertyValue('--text').trim() || '#000';
+    const bg = styles.getPropertyValue("--bg").trim() || "#ffffff";
+    const surface = styles.getPropertyValue("--surface").trim() || "#ffffff";
+    const border = styles.getPropertyValue("--border").trim() || "#ddd";
+    const text = styles.getPropertyValue("--text").trim() || "#000";
 
     let wrapper = null;
     if (isMobile) {
       // 縦型: フィルタ済みデータから手動でカード要素を生成
-      wrapper = document.createElement('div');
+      wrapper = document.createElement("div");
       wrapper.style.backgroundColor = bg;
       wrapper.style.color = text;
-      wrapper.style.padding = '1rem';
-      filtered.forEach(r => {
-        const card = document.createElement('div');
-        card.style.margin = '0.5rem 0';
-        card.style.padding = '0.75rem';
+      wrapper.style.padding = "1rem";
+      filtered.forEach((r) => {
+        const card = document.createElement("div");
+        card.style.margin = "0.5rem 0";
+        card.style.padding = "0.75rem";
         card.style.border = `1px solid ${border}`;
-        card.style.borderRadius = '4px';
+        card.style.borderRadius = "4px";
         card.style.background = surface;
         const fields = [
-          ['締切', r.締切.toFormat('yyyy-MM-dd HH:mm')],
-          ['教材', r.教材],
-          ['コース', r.コース名],
-          ['状態', r.状態]
+          ["締切", r.締切.toFormat("yyyy-MM-dd HH:mm")],
+          ["教材", r.教材],
+          ["コース", r.コース名],
+          ["状態", r.状態],
         ];
         fields.forEach(([label, value]) => {
-          const row = document.createElement('div');
-          row.style.marginBottom = '0.25rem';
-          const keyEl = document.createElement('span');
-          keyEl.style.fontWeight = 'bold';
+          const row = document.createElement("div");
+          row.style.marginBottom = "0.25rem";
+          const keyEl = document.createElement("span");
+          keyEl.style.fontWeight = "bold";
           keyEl.textContent = `${label}: `;
-          const valEl = document.createElement('span');
+          const valEl = document.createElement("span");
           valEl.textContent = value;
           row.appendChild(keyEl);
           row.appendChild(valEl);
@@ -342,25 +409,28 @@ export default function App() {
       // 横型: テーブルをクローンしてラッパーに入れる
       const container = tableRef.current;
       if (!container) return;
-      const tableEl = container.querySelector('table');
+      const tableEl = container.querySelector("table");
       if (!tableEl) return;
-      wrapper = document.createElement('div');
+      wrapper = document.createElement("div");
       wrapper.style.backgroundColor = bg;
       wrapper.style.color = text;
-      wrapper.style.padding = '1rem';
+      wrapper.style.padding = "1rem";
       wrapper.appendChild(tableEl.cloneNode(true));
       document.body.appendChild(wrapper);
     }
     // html2canvas でキャプチャ
-  html2canvas(wrapper, {
+    html2canvas(wrapper, {
       scale: 2,
       backgroundColor: bg,
       useCORS: true,
       width: wrapper.scrollWidth,
-      height: wrapper.scrollHeight
+      height: wrapper.scrollHeight,
     })
-      .then(canvas =>
-        canvas.toBlob(blob => openPreview(blob, name, 'image/png'), 'image/png')
+      .then((canvas) =>
+        canvas.toBlob(
+          (blob) => openPreview(blob, name, "image/png"),
+          "image/png",
+        ),
       )
       .catch(() => alert(`${name} の生成に失敗しました`))
       .finally(() => {
@@ -370,10 +440,24 @@ export default function App() {
 
   const shareToReminders = () => {
     if (!navigator.canShare || !navigator.canShare({ files: [] })) return;
-    const { error, value } = createEvents({ events: filtered.map(r => ({ start:[r.締切.year,r.締切.month,r.締切.day,r.締切.hour,r.締切.minute], title:`${r.教材} (${r.コース名})` })) });
+    const { error, value } = createEvents({
+      events: filtered.map((r) => ({
+        start: [
+          r.締切.year,
+          r.締切.month,
+          r.締切.day,
+          r.締切.hour,
+          r.締切.minute,
+        ],
+        title: `${r.教材} (${r.コース名})`,
+      })),
+    });
     if (!error) {
-      const file = new File([new Blob([value], { type: 'text/calendar' })], 'webclass_todo.ics');
-      navigator.share({ files: [file], title: 'WebClass To-Do' });
+      const file = new File(
+        [new Blob([value], { type: "text/calendar" })],
+        "webclass_todo.ics",
+      );
+      navigator.share({ files: [file], title: "WebClass To-Do" });
     }
   };
 
@@ -385,116 +469,259 @@ export default function App() {
     const today = DateTime.local().toISODate();
     setDaysFilter(DEFAULT_SPAN_DAYS);
     setStartDate(today);
-    setEndDate(DateTime.fromISO(today).plus({ days: DEFAULT_SPAN_DAYS }).toISODate());
+    setEndDate(
+      DateTime.fromISO(today).plus({ days: DEFAULT_SPAN_DAYS }).toISODate(),
+    );
     setStatuses([]);
     setKeyword("");
 
-    sessionStorage.removeItem('webclass-todo');
+    sessionStorage.removeItem("webclass-todo");
 
     if (fileInputRef.current) {
-      fileInputRef.current.value = '';
+      fileInputRef.current.value = "";
     }
   };
 
   // Render
   return (
     <>
-    <div className="container">
-      <header>
-        <h1>📋 WebClass To-Do</h1>
-        {/* ファイル解除ボタンはデータ読み込み後だけ表示 */}
-        {data.length > 0 && (
-          <button onClick={clearFile} style={{ marginLeft: '1rem' }}>
-            🚪 ファイル選択解除
-          </button>
-        )}
-      </header>
-      {!data.length && (
-        <>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept=".csv"
-            onChange={handleFile}
-          />
-          <p>課題実施状況一覧のCSVを選択してください。</p>
-        </>
-      )}
-      {data.length > 0 && (
-        <>
-          <aside className="sidebar">
-            <details
-              className="filter-accordion"
-              open={isFilterOpen}
-              onToggle={e => setIsFilterOpen(e.target.open)}
-            >
-              <summary>🔍 抽出条件</summary>
-              <div className="filter-fields">
-                <label htmlFor="daysFilter">期間を指定（日）:</label>
-                <div className="number-spinner">
-                  <button
-                    type="button"
-                    onClick={() => setDaysFilter(d => Math.max(0, d - 1))}
-                    aria-label="減らす"
-                  >
-                    −
-                  </button>
-                  <input
-                    id="daysFilter"
-                    type="number"
-                    min={0}
-                    value={daysFilter}
-                    onChange={e => setDaysFilter(Number(e.target.value))}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setDaysFilter(d => d + 1)}
-                    aria-label="増やす"
-                  >
-                    ＋
-                  </button>
-                </div>
-                <label>開始日:<input type="date" value={startDate} onChange={e => setStartDate(e.target.value)} /></label>
-                <label>終了日:<input type="date" value={endDate} onChange={e => setEndDate(e.target.value)} /></label>
-                <label>状態で絞り込み:<select multiple value={statuses} onChange={e => setStatuses(Array.from(e.target.selectedOptions, o => o.value))}>{[...new Set(data.map(r => r.状態))].map(s => <option key={s} value={s}>{s}</option>)}</select></label>
-                <label>キーワード:<input type="text" placeholder="例: Python" value={keyword} onChange={e => setKeyword(e.target.value)} /></label>
-              </div>
-            </details>
-          </aside>
-          <main className="main">
-            <div className="metrics"><span>抽出件数: {filtered.length}</span>{filtered.length > 0 && <span>次の締切: {filtered[0].締切.toFormat('yyyy-MM-dd')}</span>}</div>
-            <div className="table-container" ref={tableRef} style={{ overflowX: 'auto' }}>
-              <table style={{ fontSize: '0.875rem', lineHeight: '1.4' }}>
-                <thead><tr><th>締切</th><th>教材</th><th>コース名</th><th>状態</th></tr></thead><tbody>{filtered.map((r,i) => <tr key={i}><td>{r.締切.toFormat('yyyy-MM-dd HH:mm')}</td><td>{r.教材}</td><td>{r.コース名}</td><td>{r.状態}</td></tr>)}</tbody>
-              </table>
-            </div>
-            <div className="button-group">
-              <button onClick={exportCSV}>CSV ダウンロード</button>
-              <button onClick={exportICS}>iCalendar (.ics) ダウンロード</button>
-              <button onClick={exportTodoist}>Todoist CSV ダウンロード</button>
-              <button onClick={() => exportPNGTable(false)}>PNG（テーブル）</button>
-              <button onClick={exportPNGList}>PNG（縦リスト）</button>
-            </div>
-            <div className="mobile-container" ref={mobileRef} style={{display:'none'}}>{filtered.map((r,i) => <div key={i} style={{margin:'0.5rem 0',padding:'0.75rem',border:'1px solid #ddd',borderRadius:'4px',background:'#fff'}}><div><strong>締切:</strong> {r.締切.toFormat('yyyy-MM-dd HH:mm')}</div><div><strong>教材:</strong> {r.教材}</div><div><strong>コース:</strong> {r.コース名}</div><div><strong>状態:</strong> {r.状態}</div></div>)}</div>
-          </main>
-        </>
-      )}
-    </div>
-    {preview && (
-      <div className="modal-overlay" onClick={closePreview}>
-        <div className="modal" onClick={e => e.stopPropagation()}>
-          {preview.mime.startsWith('image/') ? (
-            <img src={preview.url} alt={preview.name} style={{maxWidth:'100%'}} />
-          ) : (
-            <iframe src={preview.url} title="preview" style={{width:'80vw',height:'60vh',border:'none'}} />
+      <div className="container">
+        <header>
+          <h1>📋 WebClass To-Do</h1>
+          {/* ファイル解除ボタンはデータ読み込み後だけ表示 */}
+          {data.length > 0 && (
+            <button onClick={clearFile} style={{ marginLeft: "1rem" }}>
+              🚪 ファイル選択解除
+            </button>
           )}
-          <div style={{textAlign:'right',marginTop:'1rem'}}>
-            <button onClick={confirmDownload} className="primary">ダウンロード</button>
-            <button onClick={closePreview} style={{marginLeft:'0.5rem'}}>閉じる</button>
+        </header>
+        {!data.length && (
+          <>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".csv"
+              onChange={handleFile}
+            />
+            <p>課題実施状況一覧のCSVを選択してください。</p>
+          </>
+        )}
+        {data.length > 0 && (
+          <>
+            <aside className="sidebar">
+              <details
+                className="filter-accordion"
+                open={isFilterOpen}
+                onToggle={(e) => setIsFilterOpen(e.target.open)}
+              >
+                <summary>🔍 抽出条件</summary>
+                <div className="filter-fields">
+                  <label htmlFor="daysFilter">期間を指定（日）:</label>
+                  <div className="number-spinner">
+                    <button
+                      type="button"
+                      onClick={() => setDaysFilter((d) => Math.max(0, d - 1))}
+                      aria-label="減らす"
+                    >
+                      −
+                    </button>
+                    <input
+                      id="daysFilter"
+                      type="number"
+                      min={0}
+                      value={daysFilter}
+                      onChange={(e) => setDaysFilter(Number(e.target.value))}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setDaysFilter((d) => d + 1)}
+                      aria-label="増やす"
+                    >
+                      ＋
+                    </button>
+                  </div>
+                  <label>
+                    開始日:
+                    <input
+                      type="date"
+                      value={startDate}
+                      onChange={(e) => setStartDate(e.target.value)}
+                    />
+                  </label>
+                  <label>
+                    終了日:
+                    <input
+                      type="date"
+                      value={endDate}
+                      onChange={(e) => setEndDate(e.target.value)}
+                    />
+                  </label>
+                  <label>
+                    状態で絞り込み:
+                    <select
+                      multiple
+                      value={statuses}
+                      onChange={(e) =>
+                        setStatuses(
+                          Array.from(e.target.selectedOptions, (o) => o.value),
+                        )
+                      }
+                    >
+                      {[...new Set(data.map((r) => r.状態))].map((s) => (
+                        <option key={s} value={s}>
+                          {s}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label>
+                    キーワード:
+                    <input
+                      type="text"
+                      placeholder="例: Python"
+                      value={keyword}
+                      onChange={(e) => setKeyword(e.target.value)}
+                    />
+                  </label>
+                </div>
+              </details>
+            </aside>
+            <main className="main">
+              <div className="metrics">
+                <span>抽出件数: {filtered.length}</span>
+                {filtered.length > 0 && (
+                  <span>
+                    次の締切: {filtered[0].締切.toFormat("yyyy-MM-dd")}
+                  </span>
+                )}
+              </div>
+              <div
+                className="table-container"
+                ref={tableRef}
+                style={{ overflowX: "auto" }}
+              >
+                <table style={{ fontSize: "0.875rem", lineHeight: "1.4" }}>
+                  <thead>
+                    <tr>
+                      <th>締切</th>
+                      <th>教材</th>
+                      <th>コース名</th>
+                      <th>状態</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filtered.map((r, i) => (
+                      <tr key={i}>
+                        <td>{r.締切.toFormat("yyyy-MM-dd HH:mm")}</td>
+                        <td>{r.教材}</td>
+                        <td>{r.コース名}</td>
+                        <td>{r.状態}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <div className="button-group">
+                <button onClick={exportCSV}>CSV ダウンロード</button>
+                <button onClick={exportICS}>
+                  iCalendar (.ics) ダウンロード
+                </button>
+                <button onClick={exportTodoist}>
+                  Todoist CSV ダウンロード
+                </button>
+                <button onClick={() => exportPNGTable(false)}>
+                  PNG（テーブル）
+                </button>
+                <button onClick={exportPNGList}>PNG（縦リスト）</button>
+              </div>
+              <div
+                className="mobile-container"
+                ref={mobileRef}
+                style={{ display: "none" }}
+              >
+                {filtered.map((r, i) => (
+                  <div
+                    key={i}
+                    style={{
+                      margin: "0.5rem 0",
+                      padding: "0.75rem",
+                      border: "1px solid #ddd",
+                      borderRadius: "4px",
+                      background: "#fff",
+                    }}
+                  >
+                    <div>
+                      <strong>締切:</strong>{" "}
+                      {r.締切.toFormat("yyyy-MM-dd HH:mm")}
+                    </div>
+                    <div>
+                      <strong>教材:</strong> {r.教材}
+                    </div>
+                    <div>
+                      <strong>コース:</strong> {r.コース名}
+                    </div>
+                    <div>
+                      <strong>状態:</strong> {r.状態}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </main>
+          </>
+        )}
+      </div>
+      {preview && (
+        <div className="modal-overlay" onClick={closePreview}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            {preview.mime.startsWith("image/") ? (
+              <img
+                src={preview.url}
+                alt={preview.name}
+                style={{
+                  maxWidth: "80vw",
+                  maxHeight: "80vh",
+                  objectFit: "contain",
+                }}
+              />
+            ) : preview.mime === "text/csv" ? (
+              <div className="csv-preview">
+                <table>
+                  <thead>
+                    <tr>
+                      {preview.rows[0].map((h, i) => (
+                        <th key={i}>{h}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {preview.rows.slice(1).map((row, i) => (
+                      <tr key={i}>
+                        {row.map((cell, j) => (
+                          <td key={j}>{cell}</td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <iframe
+                src={preview.url}
+                title="preview"
+                style={{ width: "80vw", height: "60vh", border: "none" }}
+              />
+            )}
+            <div style={{ textAlign: "right", marginTop: "1rem" }}>
+              <button onClick={confirmDownload} className="primary">
+                ダウンロード
+              </button>
+              <button onClick={closePreview} style={{ marginLeft: "0.5rem" }}>
+                閉じる
+              </button>
+            </div>
           </div>
         </div>
-      </div>
-    )}
+      )}
     </>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -437,3 +437,24 @@ input[type="number"]::-webkit-outer-spin-button {
 input[type="number"] {
   -moz-appearance: textfield;
 }
+
+/* ---------------- Preview Modal ---------------- */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.modal {
+  background: var(--surface);
+  color: var(--text);
+  padding: 1rem;
+  border-radius: var(--radius);
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow: auto;
+  box-shadow: var(--shadow-md);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -10,18 +10,18 @@
 /* ---------------- Root palette & typography ---------------- */
 :root {
   /* Light theme */
-  --bg:            #f9fafb;
-  --surface:       #ffffff;
+  --bg: #f9fafb;
+  --surface: #ffffff;
   --surface-hover: #f1f5f9;
-  --border:        #e5e7eb;
-  --text:          #1f2937;
-  --text-secondary:#1f2937;
-  --primary:       #3b82f6;
-  --primary-dim:   #2563eb;
-  --radius:        0.75rem;
-  --gap:           1.25rem;
+  --border: #e5e7eb;
+  --text: #1f2937;
+  --text-secondary: #1f2937;
+  --primary: #3b82f6;
+  --primary-dim: #2563eb;
+  --radius: 0.75rem;
+  --gap: 1.25rem;
   --sidebar-width: 260px;
-  --font:          "Noto Sans JP", "Helvetica Neue", Arial, sans-serif;
+  --font: "Noto Sans JP", "Helvetica Neue", Arial, sans-serif;
 
   /* Elevation */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
@@ -30,14 +30,14 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg:            #121212;
-    --surface:       #1A1A1A;
-    --surface-hover: #2A2A2A;
-    --border:        #333333;
-    --text:          #E0E0E0;
-    --text-secondary:#9E9E9E;
-    --primary:       #3b82f6;
-    --primary-dim:   #60a5fa;
+    --bg: #121212;
+    --surface: #1a1a1a;
+    --surface-hover: #2a2a2a;
+    --border: #333333;
+    --text: #e0e0e0;
+    --text-secondary: #9e9e9e;
+    --primary: #3b82f6;
+    --primary-dim: #60a5fa;
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.6);
     --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.55);
   }
@@ -45,20 +45,20 @@
   input[type="number"],
   input[type="text"],
   select {
-    background: #2A2A2A;
-    color: #FFFFFF;
+    background: #2a2a2a;
+    color: #ffffff;
   }
 
   button,
   .button,
   .number-spinner button {
-    background: #2D2D2D;
-    color: #FFFFFF;
+    background: #2d2d2d;
+    color: #ffffff;
   }
   button:hover,
   .button:hover,
   .number-spinner button:hover {
-    background: #3C3C3C;
+    background: #3c3c3c;
   }
 
   input:focus-visible,
@@ -68,22 +68,25 @@
   }
 
   .table-container tr:hover {
-    background: #2A2A2A;
+    background: #2a2a2a;
   }
 
   .mobile-container > div {
-    background: #1A1A1A !important;
+    background: #1a1a1a !important;
     border-color: #333333 !important;
-    color: #E0E0E0;
+    color: #e0e0e0;
   }
 }
 
 /* ---------------- Reset ---------------- */
 *,
 *::before,
-*::after { box-sizing: border-box; }
+*::after {
+  box-sizing: border-box;
+}
 
-html, body {
+html,
+body {
   height: 100%;
 }
 
@@ -98,13 +101,20 @@ body {
 }
 
 /* Remove tap-highlight on mobile */
-button, input, select {
+button,
+input,
+select {
   font: inherit;
   -webkit-tap-highlight-color: transparent;
 }
 
-a { color: var(--primary); text-decoration: none; }
-a:hover { text-decoration: underline; }
+a {
+  color: var(--primary);
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
 
 /* ---------------- Layout container ---------------- */
 .container {
@@ -152,7 +162,9 @@ header img.logo {
     grid-template-columns: var(--sidebar-width) 1fr;
     gap: var(--gap);
   }
-  header { grid-column: 1 / -1; }
+  header {
+    grid-column: 1 / -1;
+  }
   .container > input[type="file"],
   .container > p {
     grid-column: 1 / -1;
@@ -182,7 +194,9 @@ header img.logo {
 }
 
 .filter-accordion summary::marker,
-.filter-accordion summary::-webkit-details-marker { display: none; }
+.filter-accordion summary::-webkit-details-marker {
+  display: none;
+}
 
 .filter-accordion summary::after {
   content: "›";
@@ -304,7 +318,9 @@ button,
   background: var(--surface);
   cursor: pointer;
   box-shadow: var(--shadow-sm);
-  transition: background 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    background 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 button:hover,
@@ -389,7 +405,9 @@ button.primary:hover {
   border-radius: var(--radius);
   background: var(--surface-hover);
   cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
 }
 
 .container > input[type="file"]:hover {
@@ -457,4 +475,33 @@ input[type="number"] {
   max-height: 90vh;
   overflow: auto;
   box-shadow: var(--shadow-md);
+}
+
+.csv-preview {
+  overflow: auto;
+  max-width: 80vw;
+  max-height: 60vh;
+}
+
+.csv-preview table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.csv-preview th,
+.csv-preview td {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--border);
+  font-size: 0.875rem;
+  white-space: nowrap;
+}
+
+.csv-preview th {
+  background: var(--surface-hover);
+}
+
+.modal img {
+  max-width: 80vw;
+  max-height: 80vh;
+  object-fit: contain;
 }


### PR DESCRIPTION
## Summary
- preview downloaded CSV and PNG files in a popup
- allow user to confirm download from preview
- keep ICS export behavior unchanged
- add simple modal styles

## Testing
- `npm run build` *(fails: esbuild for another platform)*

------
https://chatgpt.com/codex/tasks/task_e_687bfb5043e08326bf70d43736c7d6d9