### PR TITLE
Fix PNG table capture styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -104,6 +104,10 @@ const buildImageWrapper = (isMobile, filtered, tableRef) => {
     if (!container) return null;
     const tableEl = container.querySelector("table");
     if (!tableEl) return null;
+    wrapper.className = container.className || "";
+    if (container.style.cssText) {
+      wrapper.style.cssText += container.style.cssText;
+    }
     wrapper.appendChild(tableEl.cloneNode(true));
   }
   return wrapper;


### PR DESCRIPTION
## Summary
- ensure table-style screenshots apply table container classes without overwriting defaults

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687c1e18b64c8326bfdb132d6c5cf9dd