### PR TITLE
Add usage page with link from upload screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -459,6 +459,11 @@ export default function App() {
               onChange={handleFile}
             />
             <p>課題実施状況一覧のCSVを選択してください。</p>
+            <p>
+              <a href="usage.html" target="_blank" rel="noopener" className="button">
+                使い方を見る
+              </a>
+            </p>
           </>
         )}
         {data.length > 0 && (

--- a/usage.html
+++ b/usage.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>使い方 - WebClass To-Do</title>
+  <link rel="stylesheet" href="/src/index.css" />
+</head>
+<body>
+  <header style="padding: 1rem; text-align: center;">
+    <h1>📋 WebClass To-Do の使い方</h1>
+  </header>
+  <main style="max-width: 800px; margin: auto; padding: 1rem; line-height: 1.6;">
+    <ol>
+      <li>WebClass から「課題実施状況一覧」を CSV 形式でダウンロードします。</li>
+      <li>トップページでその CSV ファイルを選択します。</li>
+      <li>必要に応じて期間やキーワードなどの条件を設定します。</li>
+      <li>表示された一覧を各種フォーマットでエクスポートできます。</li>
+    </ol>
+    <p>ブラウザだけで動作するので、インストールは不要です。</p>
+    <p><a href="index.html">トップへ戻る</a></p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `usage.html` describing how to use the tool
- add link button on upload screen to open the new page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687cb220a2148326b4bf384f96b91e19