### PR TITLE
Add usage page with link from upload screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,10 +5,11 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>📋 WebClass To-Do</title>
-  <link rel="stylesheet" href="/src/index.css" />
+  <!-- Use relative path so production build can find the CSS -->
+  <link rel="stylesheet" href="./src/index.css" />
 </head>
 <body>
   <div id="root"></div>
-  <script type="module" src="/src/main.jsx"></script>
+  <script type="module" src="./src/main.jsx"></script>
 </body>
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -460,7 +460,7 @@ export default function App() {
             />
             <p>課題実施状況一覧のCSVを選択してください。</p>
             <p>
-              <a href="usage.html" target="_blank" rel="noopener" className="button">
+              <a href="./usage.html" target="_blank" rel="noopener" className="button">
                 使い方を見る
               </a>
             </p>

--- a/usage.html
+++ b/usage.html
@@ -4,7 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>使い方 - WebClass To-Do</title>
-  <link rel="stylesheet" href="/src/index.css" />
+  <!-- Use relative path so it works in production -->
+  <link rel="stylesheet" href="./src/index.css" />
 </head>
 <body>
   <header style="padding: 1rem; text-align: center;">

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,17 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+// Include both index.html and usage.html in the build so the help page
+// works when deployed.
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        usage: resolve(__dirname, 'usage.html'),
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- create `usage.html` describing how to use the tool
- add link button on upload screen to open the new page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687cb220a2148326b4bf384f96b91e19