### PR TITLE
Add sortable table columns

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -374,6 +374,14 @@ button.primary:hover {
   font-weight: 600;
 }
 
+.table-container th.sortable {
+  cursor: pointer;
+}
+.table-container th.sortable .arrow {
+  margin-left: 0.25rem;
+  font-size: 0.75rem;
+}
+
 .table-container tr:hover {
   background: var(--surface-hover);
 }


### PR DESCRIPTION
## Summary
- make columns sortable with ascending/descending toggle
- store/restore sorting state in sessionStorage
- display next deadline independent of sort order
- style sortable table headers

## Testing
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687cb603740c832690b3625f0f505f2b