### PR TITLE
Improve mobile layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -152,9 +152,8 @@ export default function App() {
   // ファイル入力要素をクリアするための ref
   const fileInputRef = useRef(null);
 
-  // テーブルとモバイル用コンテナの参照（忘れるとレンダリング時にエラーになります）
+  // テーブルの参照（PNG 書き出し用）
   const tableRef = useRef(null);
-  const mobileRef = useRef(null);
   const [preview, setPreview] = useState(null); // {url, name, mime, blob}
 
   // フィルタ条件のみリセット
@@ -663,37 +662,30 @@ export default function App() {
                 </button>
                 <button onClick={exportPNGList}>PNG（縦リスト）</button>
               </div>
-              <div
-                className="mobile-container"
-                ref={mobileRef}
-                style={{ display: "none" }}
-              >
-                {filtered.map((r, i) => (
-                  <div
-                    key={i}
-                    style={{
-                      margin: "0.5rem 0",
-                      padding: "0.75rem",
-                      border: "1px solid #ddd",
-                      borderRadius: "4px",
-                      background: "#fff",
-                    }}
-                  >
-                    <div>
-                      <strong>締切:</strong>{" "}
-                      {r.締切.toFormat("yyyy-MM-dd HH:mm")}
+              <div className="list-container">
+                {Object.entries(
+                  filtered.reduce((acc, r) => {
+                    const d = r.締切.toFormat("yyyy-MM-dd");
+                    acc[d] = acc[d] ? [...acc[d], r] : [r];
+                    return acc;
+                  }, {})
+                )
+                  .sort(([a], [b]) => (a < b ? -1 : 1))
+                  .map(([date, rows]) => (
+                    <div key={date} className="list-day">
+                      <h3 className="list-date">{date}</h3>
+                      {rows.map((r, i) => (
+                        <div key={i} className="list-item">
+                          <div className="list-title">{r.教材}</div>
+                          <div className="list-meta">
+                            <span>{r.締切.toFormat("HH:mm")}</span>
+                            <span>{r.コース名}</span>
+                            <span>{r.状態}</span>
+                          </div>
+                        </div>
+                      ))}
                     </div>
-                    <div>
-                      <strong>教材:</strong> {r.教材}
-                    </div>
-                    <div>
-                      <strong>コース:</strong> {r.コース名}
-                    </div>
-                    <div>
-                      <strong>状態:</strong> {r.状態}
-                    </div>
-                  </div>
-                ))}
+                  ))}
               </div>
             </main>
           </>

--- a/src/index.css
+++ b/src/index.css
@@ -71,9 +71,9 @@
     background: #2a2a2a;
   }
 
-  .mobile-container > div {
-    background: #1a1a1a !important;
-    border-color: #333333 !important;
+  .list-item {
+    background: #1a1a1a;
+    border-color: #333333;
     color: #e0e0e0;
   }
 }
@@ -352,6 +352,54 @@ button.primary:hover {
   border-radius: var(--radius);
   background: var(--surface);
   box-shadow: var(--shadow-sm);
+}
+
+/* ---------------- Mobile list ---------------- */
+.list-container {
+  display: none;
+  width: 100%;
+}
+
+.list-date {
+  font-weight: 600;
+  margin: 1rem 0 0.25rem;
+}
+
+.list-item {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  padding: 0.75rem;
+  margin-bottom: 0.5rem;
+  line-height: 1.4;
+}
+
+.list-title {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+  word-break: break-word;
+}
+
+.list-meta {
+  font-size: 0.875rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+@media (max-width: 767px) {
+  .table-container {
+    display: none;
+  }
+  .list-container {
+    display: block;
+  }
+}
+
+@media (min-width: 768px) {
+  .list-container {
+    display: none;
+  }
 }
 
 .table-container table {


### PR DESCRIPTION
## Summary
- switch to single-column tile layout on small screens
- group todos by date headings
- add responsive CSS for the new list design

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687cb9d3fb348326b71029dddd449e3d