### PR TITLE
Improve button group layout for responsive UI

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -315,9 +315,20 @@ select {
   margin-bottom: var(--gap);
 }
 
+@media (max-width: 600px) {
+  .button-group {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+  .button-group > * {
+    width: 100%;
+  }
+}
+
 button,
 .button {
-  padding: 0.55rem 1.1rem;
+  padding: 0.6rem 1.2rem;
+  font-size: 0.95rem;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--surface);
@@ -326,6 +337,14 @@ button,
   transition:
     background 0.15s ease,
     box-shadow 0.15s ease;
+}
+
+@media (max-width: 600px) {
+  button,
+  .button {
+    padding: 0.8rem 1.2rem;
+    font-size: 1rem;
+  }
 }
 
 button:hover,


### PR DESCRIPTION
## Summary
- tweak button group for better mobile experience
- increase button padding and font size on mobile screens

## Testing
- `npm run build` *(fails: "@esbuild/darwin-arm64" package is present but this platform needs "@esbuild/linux-x64")*

------
https://chatgpt.com/codex/tasks/task_e_687cbaaa0dc88326a31d75671a3b7c2e