### PR TITLE
Improve button layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -313,11 +313,24 @@ select {
   flex-wrap: wrap;
   gap: 0.75rem;
   margin-bottom: var(--gap);
+  justify-content: center;
+}
+
+@media (max-width: 767px) {
+  .button-group {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+  .button-group button,
+  .button-group .button {
+    width: 100%;
+    font-size: 1rem;
+  }
 }
 
 button,
 .button {
-  padding: 0.55rem 1.1rem;
+  padding: 0.65rem 1.2rem;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--surface);


### PR DESCRIPTION
## Summary
- enlarge button padding for easier taps
- center download buttons
- on small screens arrange buttons in two columns

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687cbcca15488326bdaf3b857da120dc