### PR TITLE
Revamp header with responsive navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -613,14 +613,23 @@ export default function App() {
   return (
     <>
       <div className="container">
-        <header>
-          <h1 onClick={clearFile} style={{ cursor: "pointer" }}>📋 WebClass To-Do</h1>
-          {/* ファイル解除ボタンはデータ読み込み後だけ表示 */}
-          {data.length > 0 && (
-            <button onClick={clearFile} style={{ marginLeft: "1rem" }}>
-              🚪 ファイル選択解除
-            </button>
-          )}
+        <header className="app-header">
+          <h1 onClick={clearFile}>📋 WebClass To-Do</h1>
+          <nav className="nav-links">
+            {data.length > 0 && (
+              <button onClick={clearFile} className="text-button">
+                ファイル解除
+              </button>
+            )}
+            <a
+              href="./usage.html"
+              target="_blank"
+              rel="noopener"
+              className="text-button"
+            >
+              使い方
+            </a>
+          </nav>
         </header>
         {!data.length && (
           <>
@@ -631,11 +640,6 @@ export default function App() {
               onChange={handleFile}
             />
             <p>課題実施状況一覧のCSVを選択してください。</p>
-            <p>
-              <a href="./usage.html" target="_blank" rel="noopener" className="button">
-                使い方を見る
-              </a>
-            </p>
           </>
         )}
         {data.length > 0 && (

--- a/src/index.css
+++ b/src/index.css
@@ -125,26 +125,71 @@ a:hover {
   padding: var(--gap);
 }
 
-header {
+.app-header {
   margin-bottom: var(--gap);
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
-header h1 {
+.app-header h1 {
   font-size: clamp(1.5rem, 2vw + 1rem, 2rem);
   font-weight: 700;
   display: flex;
   align-items: center;
   gap: 0.5rem;
   cursor: pointer;
+  margin: 0;
 }
 
-header img.logo {
+.app-header img.logo {
   width: 2.25rem;
   height: 2.25rem;
   flex-shrink: 0;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.text-button {
+  background: none;
+  border: none;
+  color: var(--text);
+  cursor: pointer;
+  padding: 0.4rem 0.75rem;
+  border-radius: var(--radius);
+  text-decoration: none;
+  font: inherit;
+}
+
+.text-button:hover,
+.text-button:focus-visible {
+  background: var(--surface-hover);
+  text-decoration: none;
+}
+
+.text-button:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--primary) 60%, transparent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 600px) {
+  .app-header {
+    padding: 0.5rem;
+  }
+  .nav-links {
+    gap: 0.25rem;
+  }
 }
 
 .sidebar {
@@ -163,7 +208,7 @@ header img.logo {
     grid-template-columns: var(--sidebar-width) 1fr;
     gap: var(--gap);
   }
-  header {
+  .app-header {
     grid-column: 1 / -1;
   }
   .container > input[type="file"],


### PR DESCRIPTION
## Summary
- replace top header with sticky responsive navigation bar
- add reusable text-button styles and navigation links

## Testing
- `npm run build` *(fails: missing @esbuild/linux-x64)*
- `npm rebuild esbuild` *(fails: 403 Forbidden fetching package)*

------
https://chatgpt.com/codex/tasks/task_e_68962213dadc83269b2ac3ef7663b6a3