### PR TITLE
Add bulk Reminders export flow

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -579,3 +579,145 @@ input[type="number"] {
   max-height: 80vh;
   object-fit: contain;
 }
+
+/* ---------------- Reminder Modal ---------------- */
+.reminder-modal {
+  width: min(640px, 90vw);
+}
+
+.reminder-description {
+  margin-top: 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.reminder-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.reminder-options label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.reminder-options select {
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: inherit;
+}
+
+.reminder-statuses {
+  margin-bottom: 1.25rem;
+}
+
+.reminder-statuses > span {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.status-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.5rem;
+}
+
+.status-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+  font-size: 0.9rem;
+}
+
+.status-item input[type="checkbox"] {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.status-empty {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.status-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.status-actions button {
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface-hover);
+  cursor: pointer;
+}
+
+.status-actions button:hover {
+  background: var(--primary);
+  color: #fff;
+}
+
+.reminder-preview h3 {
+  margin-bottom: 0.75rem;
+}
+
+.reminder-preview-list {
+  max-height: 240px;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.reminder-preview-list ol {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.reminder-preview-list li {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.preview-title {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.preview-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.reminder-empty {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1.25rem;
+}


### PR DESCRIPTION
## Summary
- add a dedicated modal to review and sort filtered tasks before sending them to iPhone Reminders
- generate VTODO-based ICS content, sharing it via the Web Share API with a download fallback for unsupported devices
- style the new Reminders workflow controls and preview list for clarity on mobile and desktop

## Testing
- npm run build *(fails: repository ships macOS esbuild binary; linux binary is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f65d8043d0832691c8ff5a5e9ba304