### PR TITLE
Add reminder export modal for filtered tasks

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -551,6 +551,109 @@ input[type="number"] {
   box-shadow: var(--shadow-md);
 }
 
+.reminder-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: min(480px, 90vw);
+}
+
+.reminder-controls {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+  font-size: 0.95rem;
+}
+
+.reminder-controls label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.reminder-controls select {
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+}
+
+.order-toggle {
+  gap: 0.35rem;
+}
+
+.reminder-statuses {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.status-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+}
+
+.status-options label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  background: var(--surface-hover);
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+}
+
+.reminder-preview {
+  background: var(--surface-hover);
+  border-radius: var(--radius);
+  padding: 0.75rem;
+  max-height: 40vh;
+  overflow: auto;
+}
+
+.reminder-preview ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.reminder-preview li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  background: var(--surface);
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  padding: 0.6rem 0.75rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.reminder-preview-title {
+  font-weight: 600;
+}
+
+.reminder-preview-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.reminder-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.reminder-actions button {
+  min-width: 120px;
+}
+
 .csv-preview {
   overflow: auto;
   max-width: 80vw;


### PR DESCRIPTION
## Summary
- add a dedicated reminder export modal that lets users adjust sort order and status filters before sending tasks
- generate iCalendar VTODO entries for the selected assignments and trigger share/download so they can be saved straight into iOS Reminders
- style the new reminder modal, preview list, and controls to match the existing UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f65d8043d0832691c8ff5a5e9ba304