### PR TITLE
Create SVG dimension assistant interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,27 @@
-# WebClass To-Do 抽出ツール
+# SVG Dimension Assistant
 
-**WebClass の課題一覧 CSV から、To-Do タスクを抽出して整形・エクスポートできる Web アプリです。**  
-モバイル対応・インストール不要・サクサク動作。
+SVG をブラウザ上で読み込み、工業図面風の寸法線と自動選択された背景色でプレビューするためのシンプルなツールです。単位を切り替えても入力値が保持されるので、コンバートに気を使わずにサイズ感を調整できます。
 
+## ✨ 主な機能
 
+- 🧾 SVG マークアップを直接貼り付けてプレビュー
+- 📐 幅・高さの入力値を単位切り替え時も保持（px / mm）
+- 🎯 アスペクト比の維持や寸法線・ラベル表示をワンタップで切り替え
+- 🧮 寸法値の整数丸め ON/OFF
+- 🎨 SVG の配色から無彩色の背景色を自動提案
+- 🏭 工業図面フォーマットの矢印・寸法テキストを自動配置
 
----
+## 🚀 使い方
 
-## 🔧 主な機能
+1. `npm install`
+2. `npm run dev` で開発サーバーを起動
+3. ブラウザで SVG マークアップを貼り付けて各種設定を調整
 
-- 📂 CSV アップロード（WebClass 課題一覧）
-- 🔍 条件抽出（締切・状態・キーワード）
-- 📅 エクスポート形式
-  - iCalendar (.ics)
-  - Todoist インポートCSV
-  - PNG（縦／表形式）
-- 📱 iPhone Safari でも動作確認済み
-- ☁️ [Cloudflare Pages でホスティング中](https://webclass-todo.pages.dev)
+## 🛠 技術スタック
 
----
+- [Vite](https://vitejs.dev/)
+- [React](https://react.dev/)
 
-## ⌨️ キーボードショートカット
+## 📄 ライセンス
 
-| 操作                        | ショートカット                     |
-|-----------------------------|------------------------------------|
-| ファイルを開く              | `Ctrl/Cmd + O`                     |
-| CSV エクスポート            | `Ctrl/Cmd + Shift + C`             |
-| iCalendar エクスポート      | `Ctrl/Cmd + Shift + I`             |
-| Todoist CSV エクスポート    | `Ctrl/Cmd + Shift + T`             |
-| PNG（テーブル）エクスポート | `Ctrl/Cmd + Shift + P`             |
-| PNG（縦リスト）エクスポート | `Ctrl/Cmd + Shift + L`             |
-| ヘルプ表示                  | `Ctrl/Cmd + H`                     |
-| プレビューを閉じる          | `Esc`                              |
-| プレビューでダウンロード           | `Enter` (プレビュー表示中) |
-| フィルタリセット           | `Ctrl/Cmd + Shift + R` |
-
----
-
-## 📦 技術スタック
-
-| 技術       | 用途               |
-|------------|--------------------|
-| [Vite](https://vitejs.dev/)       | フロントエンドビルド         |
-| React      | UI コンポーネント         |
-| Luxon      | 日付操作（タイムゾーン対応） |
-| PapaParse  | CSVパース           |
-| html2canvas| PNG 画像化         |
-| ics        | iCalendar 生成      |
-
----
-
-## 🚀 開発・ビルド手順
-
-```bash
-# 依存パッケージのインストール
-npm install
-
-# 開発サーバー起動（http://localhost:5173）
-npm run dev
-
-# ビルド（dist フォルダ生成）
-npm run build
-```
+MIT License

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>📋 WebClass To-Do</title>
+  <title>✏️ SVG Dimension Assistant</title>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9164055896922854" crossorigin="anonymous"></script>
   <!-- Use relative path so production build can find the CSS -->
   <link rel="stylesheet" href="./src/index.css" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,8 @@
             "name": "webclass-todo-frontend",
             "version": "1.0.0",
             "dependencies": {
-                "dom-to-image": "^2.6.0",
-                "html2canvas": "^1.4.1",
-                "ics": "^2.41.0",
-                "luxon": "^3.4.4",
-                "papaparse": "^5.4.1",
                 "react": "^18.2.0",
-                "react-dom": "^18.2.0",
-                "uuid": "^11.1.0"
+                "react-dom": "^18.2.0"
             },
             "devDependencies": {
                 "@vitejs/plugin-react": "^3.1.0",
@@ -268,15 +262,6 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/runtime": {
-            "version": "7.27.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-            "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/template": {
@@ -740,12 +725,6 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
-        "node_modules/@types/lodash": {
-            "version": "4.17.20",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
-            "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
-            "license": "MIT"
-        },
         "node_modules/@vitejs/plugin-react": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-3.1.0.tgz",
@@ -764,15 +743,6 @@
             },
             "peerDependencies": {
                 "vite": "^4.1.0-beta.0"
-            }
-        },
-        "node_modules/base64-arraybuffer": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-            "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6.0"
             }
         },
         "node_modules/browserslist": {
@@ -836,15 +806,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/css-line-break": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-            "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-            "license": "MIT",
-            "dependencies": {
-                "utrie": "^1.0.2"
-            }
-        },
         "node_modules/debug": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -862,12 +823,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/dom-to-image": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/dom-to-image/-/dom-to-image-2.6.0.tgz",
-            "integrity": "sha512-Dt0QdaHmLpjURjU7Tnu3AgYSF2LuOmksSGsUcE6ItvJoCWTBEmiMXcqBdNSAm9+QbbwD7JMoVsuuKX6ZVQv1qA==",
-            "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
             "version": "1.5.187",
@@ -949,29 +904,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/html2canvas": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-            "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-            "license": "MIT",
-            "dependencies": {
-                "css-line-break": "^2.1.0",
-                "text-segmentation": "^1.0.3"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/ics": {
-            "version": "2.44.0",
-            "resolved": "https://registry.npmjs.org/ics/-/ics-2.44.0.tgz",
-            "integrity": "sha512-JeiPjNeWkd7Qri/wfHqjZCtglVwRJRqy1MEFKn9QzatzxUyCOsx4YARPlLkU8UnPxpg4VtEjR+VRUG+Cvj6bDg==",
-            "license": "ISC",
-            "dependencies": {
-                "nanoid": "^3.1.23",
-                "yup": "^0.32.9"
-            }
-        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1004,18 +936,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "license": "MIT"
-        },
-        "node_modules/lodash-es": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-            "license": "MIT"
-        },
         "node_modules/loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -1038,15 +958,6 @@
                 "yallist": "^3.0.2"
             }
         },
-        "node_modules/luxon": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.1.tgz",
-            "integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/magic-string": {
             "version": "0.27.0",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
@@ -1067,16 +978,11 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/nanoclone": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
-            "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==",
-            "license": "MIT"
-        },
         "node_modules/nanoid": {
             "version": "3.3.11",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
             "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -1096,12 +1002,6 @@
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
             "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/papaparse": {
-            "version": "5.5.3",
-            "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
-            "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
             "license": "MIT"
         },
         "node_modules/picocolors": {
@@ -1139,12 +1039,6 @@
             "engines": {
                 "node": "^10 || ^12 || >=14"
             }
-        },
-        "node_modules/property-expr": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
-            "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
-            "license": "MIT"
         },
         "node_modules/react": {
             "version": "18.3.1",
@@ -1227,21 +1121,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/text-segmentation": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-            "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-            "license": "MIT",
-            "dependencies": {
-                "utrie": "^1.0.2"
-            }
-        },
-        "node_modules/toposort": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-            "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
-            "license": "MIT"
-        },
         "node_modules/update-browserslist-db": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -1271,28 +1150,6 @@
             },
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
-            }
-        },
-        "node_modules/utrie": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-            "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-            "license": "MIT",
-            "dependencies": {
-                "base64-arraybuffer": "^1.0.2"
-            }
-        },
-        "node_modules/uuid": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/vite": {
@@ -1357,24 +1214,6 @@
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/yup": {
-            "version": "0.32.11",
-            "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
-            "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.15.4",
-                "@types/lodash": "^4.14.175",
-                "lodash": "^4.17.21",
-                "lodash-es": "^4.17.21",
-                "nanoclone": "^0.2.1",
-                "property-expr": "^2.0.4",
-                "toposort": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -7,14 +7,8 @@
         "serve": "vite preview"
     },
     "dependencies": {
-        "dom-to-image": "^2.6.0",
-        "html2canvas": "^1.4.1",
-        "ics": "^2.41.0",
-        "luxon": "^3.4.4",
-        "papaparse": "^5.4.1",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "uuid": "^11.1.0"
+        "react-dom": "^18.2.0"
     },
     "devDependencies": {
         "@vitejs/plugin-react": "^3.1.0",

--- a/src/index.css
+++ b/src/index.css
@@ -1,87 +1,16 @@
-/* -----------------------------------------------------------------
- * WebClass To-Do – Neo-Modern UI (2025-07-19 Rev.B)
- * 機能は一切変更せず、見た目と操作性だけを強化しました。
- *  - ダーク／ライト両対応
- *  - モバイルファースト + CSS Grid で崩れにくいレイアウト
- *  - アクセシビリティ向上 (フォーカスリング / タッチターゲット)
- *  - 微細なアニメーションで “サクサク感”
- * ----------------------------------------------------------------- */
-
-/* ---------------- Root palette & typography ---------------- */
 :root {
-  /* Light theme */
-  --bg: #f9fafb;
+  --bg: #f5f7fb;
   --surface: #ffffff;
-  --surface-hover: #f1f5f9;
-  --border: #e5e7eb;
-  --text: #1f2937;
-  --text-secondary: #1f2937;
-  --primary: #3b82f6;
-  --primary-dim: #2563eb;
-  --radius: 0.75rem;
-  --gap: 1.25rem;
-  --sidebar-width: 260px;
-  --font: "Noto Sans JP", "Helvetica Neue", Arial, sans-serif;
-
-  /* Elevation */
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --surface-elevated: #f9fbff;
+  --text: #0f172a;
+  --muted: #64748b;
+  --accent: #2563eb;
+  --border: rgba(148, 163, 184, 0.35);
+  --radius: 0.85rem;
+  --shadow: 0 24px 45px rgba(15, 23, 42, 0.08);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #121212;
-    --surface: #1a1a1a;
-    --surface-hover: #2a2a2a;
-    --border: #333333;
-    --text: #e0e0e0;
-    --text-secondary: #9e9e9e;
-    --primary: #3b82f6;
-    --primary-dim: #60a5fa;
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.6);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.55);
-  }
-  input[type="date"],
-  input[type="number"],
-  input[type="text"],
-  select {
-    background: #2a2a2a;
-    color: #ffffff;
-  }
-
-  button,
-  .button,
-  .number-spinner button {
-    background: #2d2d2d;
-    color: #ffffff;
-  }
-  button:hover,
-  .button:hover,
-  .number-spinner button:hover {
-    background: #3c3c3c;
-  }
-
-  input:focus-visible,
-  select:focus-visible,
-  button:focus-visible {
-    outline-color: #888888;
-  }
-
-  .table-container tr:hover {
-    background: #2a2a2a;
-  }
-
-  .list-item {
-    background: #1a1a1a;
-    border-color: #333333;
-    color: #e0e0e0;
-  }
-}
-
-/* ---------------- Reset ---------------- */
-*,
-*::before,
-*::after {
+* {
   box-sizing: border-box;
 }
 
@@ -92,490 +21,307 @@ body {
 
 body {
   margin: 0;
-  font-family: var(--font);
+  font-family: "Noto Sans JP", "Inter", "Segoe UI", sans-serif;
   background: var(--bg);
   color: var(--text);
-  line-height: 1.55;
+  line-height: 1.65;
   -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-}
-
-/* Remove tap-highlight on mobile */
-button,
-input,
-select {
-  font: inherit;
-  -webkit-tap-highlight-color: transparent;
 }
 
 a {
-  color: var(--primary);
-  text-decoration: none;
-}
-a:hover {
-  text-decoration: underline;
+  color: inherit;
 }
 
-/* ---------------- Layout container ---------------- */
-.container {
-  display: block; /* mobile first */
-  width: 100%;
-  max-width: 1280px;
-  margin-inline: auto;
-  padding: var(--gap);
+textarea,
+input,
+select,
+button {
+  font: inherit;
 }
 
-header {
-  margin-bottom: var(--gap);
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-header h1 {
-  font-size: clamp(1.5rem, 2vw + 1rem, 2rem);
-  font-weight: 700;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+button {
   cursor: pointer;
 }
 
-header img.logo {
-  width: 2.25rem;
-  height: 2.25rem;
-  flex-shrink: 0;
+.dimension-app {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
 }
 
-.sidebar {
-  width: 100%;
-  margin-bottom: var(--gap);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
+.dimension-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.dimension-header h1 {
+  margin: 0;
+  font-size: clamp(1.9rem, 2vw + 1.2rem, 2.6rem);
+  letter-spacing: 0.01em;
+}
+
+.dimension-header p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 720px;
+}
+
+.dimension-main {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1.5rem;
+}
+
+.dimension-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
   background: var(--surface);
-  box-shadow: var(--shadow-sm);
-  overflow: hidden;
-}
-
-@media (min-width: 768px) {
-  .container {
-    display: grid;
-    grid-template-columns: var(--sidebar-width) 1fr;
-    gap: var(--gap);
-  }
-  header {
-    grid-column: 1 / -1;
-  }
-  .container > input[type="file"],
-  .container > p {
-    grid-column: 1 / -1;
-    justify-self: center;
-  }
-  .sidebar {
-    position: sticky;
-    top: var(--gap);
-    height: calc(100vh - 2 * var(--gap) - 2.5rem);
-    display: flex;
-    flex-direction: column;
-  }
-}
-
-/* ---------------- Sidebar accordion ---------------- */
-.filter-accordion {
-  padding: var(--gap);
-}
-
-.filter-accordion summary {
-  cursor: pointer;
-  font-weight: 600;
-  list-style: none;
-  outline: none;
-  display: flex;
-  align-items: center;
-}
-
-.filter-accordion summary::marker,
-.filter-accordion summary::-webkit-details-marker {
-  display: none;
-}
-
-.filter-accordion summary::after {
-  content: "›";
-  margin-left: auto;
-  transform: rotate(90deg);
-  transition: transform 0.2s ease;
-}
-
-details[open] > summary::after {
-  transform: rotate(180deg);
-}
-
-.filter-fields {
-  margin-top: var(--gap);
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.filter-fields label {
-  font-size: 0.875rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-input[type="date"],
-input[type="number"],
-select {
-  padding: 0.5rem 0.75rem;
-  border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: var(--surface-hover);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
-.number-spinner {
+.section-title {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.dimension-editor textarea {
+  min-height: 220px;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 1rem;
+  background: var(--surface-elevated);
+  color: inherit;
+  resize: vertical;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dimension-editor textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  background: #fff;
+}
+
+.error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #b91c1c;
+  font-size: 0.9rem;
+}
+
+.dimension-inputs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 1rem;
+}
+
+.dimension-inputs label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.input-composite {
   display: flex;
   align-items: stretch;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  overflow: hidden;
+  background: var(--surface-elevated);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.number-spinner button {
-  width: 2.25rem;
-  border: 1px solid var(--border);
-  background: var(--surface);
-  cursor: pointer;
+.input-composite:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+  background: #fff;
 }
 
-.number-spinner button:hover {
-  background: var(--surface-hover);
-}
-
-.number-spinner input {
-  width: 4rem;
-  text-align: center;
-  border: 1px solid var(--border);
-  border-inline: none;
-  background: var(--surface-hover);
-}
-
-.reset-btn {
-  align-self: flex-start;
-}
-
-/* ---------------- Metrics ---------------- */
-.metrics {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1.5rem;
-  font-weight: 600;
-  margin-bottom: var(--gap);
-}
-
-.metrics .metric {
-  min-width: 6rem;
-}
-
-/* ---------------- Tabs ---------------- */
-.tabs {
-  display: flex;
-  gap: 1.5rem;
-  margin-bottom: var(--gap);
-  border-bottom: 1px solid var(--border);
-}
-
-.tabs button {
-  background: none;
+.input-composite input {
+  flex: 1;
   border: none;
-  padding: 0.75rem 0;
+  background: transparent;
+  padding: 0.65rem 0.85rem;
+  min-width: 0;
+  color: inherit;
+}
+
+.input-composite input:focus {
+  outline: none;
+}
+
+.input-composite select {
+  border: none;
+  border-left: 1px solid rgba(148, 163, 184, 0.35);
+  background: transparent;
+  padding: 0.65rem 0.9rem;
+  color: inherit;
+  font-weight: 600;
+}
+
+.unit-label {
+  display: flex;
+  align-items: center;
+  padding: 0 0.9rem;
+  border-left: 1px solid rgba(148, 163, 184, 0.35);
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.toggle-group {
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+.toggle input {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.background-preview {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: 0.75rem;
+  background: var(--surface-elevated);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.swatch {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.swatch-label {
   font-weight: 500;
-  cursor: pointer;
+  color: var(--text);
+}
+
+.dimension-preview {
+  gap: 1.25rem;
+}
+
+.preview-frame {
+  min-height: 320px;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1.6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface-elevated);
   position: relative;
 }
 
-.tabs button::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: -1px;
-  width: 100%;
-  height: 2px;
-  background: transparent;
-  transition: background 0.2s ease;
+.preview-stage {
+  position: relative;
+  display: inline-flex;
+  overflow: visible;
 }
 
-.tabs button.active::after,
-.tabs button:hover::after {
-  background: var(--primary);
-}
-
-/* ---------------- Button group ---------------- */
-.button-group {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-bottom: var(--gap);
-  justify-content: center;
-}
-
-@media (max-width: 767px) {
-  .button-group {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-  }
-  .button-group button,
-  .button-group .button {
-    width: 100%;
-    font-size: 1rem;
-  }
-}
-
-button,
-.button {
-  padding: 0.65rem 1.2rem;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface);
-  cursor: pointer;
-  box-shadow: var(--shadow-sm);
-  transition:
-    background 0.15s ease,
-    box-shadow 0.15s ease;
-}
-
-button:hover,
-.button:hover {
-  background: var(--surface-hover);
-  box-shadow: var(--shadow-md);
-}
-
-button.primary {
-  background: var(--primary);
-  border-color: var(--primary);
-  color: #fff;
-}
-
-button.primary:hover {
-  background: var(--primary-dim);
-}
-
-/* ---------------- Table ---------------- */
-.table-container {
-  width: 100%;
-  overflow-x: auto;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface);
-  box-shadow: var(--shadow-sm);
-}
-
-/* ---------------- Mobile list ---------------- */
-.list-container {
-  display: none;
-  width: 100%;
-}
-
-.list-date {
-  font-weight: 600;
-  margin: 1rem 0 0.25rem;
-}
-
-.list-item {
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface);
-  padding: 0.75rem;
-  margin-bottom: 0.5rem;
-  line-height: 1.4;
-}
-
-.list-title {
-  font-weight: 600;
-  margin-bottom: 0.25rem;
-  word-break: break-word;
-}
-
-.list-meta {
-  font-size: 0.875rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-@media (max-width: 767px) {
-  .table-container {
-    display: none;
-  }
-  .list-container {
-    display: block;
-  }
-}
-
-@media (min-width: 768px) {
-  .list-container {
-    display: none;
-  }
-}
-
-.table-container table {
-  border-collapse: collapse;
-  width: 100%;
-  min-width: 640px;
-}
-
-.table-container th,
-.table-container td {
-  padding: 0.65rem 0.9rem;
-  white-space: nowrap;
-  border-bottom: 1px solid var(--border);
-  font-size: 0.875rem;
-}
-
-.table-container th {
-  background: var(--surface-hover);
-  text-align: left;
-  font-weight: 600;
-}
-
-.table-container th.sortable {
-  cursor: pointer;
-}
-.table-container th.sortable .arrow {
-  margin-left: 0.25rem;
-  font-size: 0.75rem;
-}
-
-.table-container tr:hover {
-  background: var(--surface-hover);
-}
-
-/* Zebra stripes */
-.table-container tr:nth-child(even) {
-  background: color-mix(in srgb, var(--surface-hover) 30%, transparent);
-}
-
-/* Sticky header for long tables */
-.table-container thead th {
-  position: sticky;
-  top: 0;
-  z-index: 1;
-}
-
-/* Hide scrollbars on WebKit */
-.table-container::-webkit-scrollbar {
-  height: 0.6rem;
-}
-.table-container::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--primary) 50%, transparent);
-  border-radius: 9999px;
-}
-
-/* ---------------- File Uploader (no-data state) ---------------- */
-.container > input[type="file"] {
+.svg-content svg {
   display: block;
-  margin: 4rem auto 0 auto;
   width: 100%;
-  max-width: 520px;
-  padding: 3rem 1.5rem;
-  border: 2px dashed var(--border);
-  border-radius: var(--radius);
-  background: var(--surface-hover);
-  cursor: pointer;
-  transition:
-    background 0.15s ease,
-    border-color 0.15s ease;
+  max-width: 460px;
+  height: auto;
+  overflow: visible;
 }
 
-.container > input[type="file"]:hover {
-  background: var(--surface);
-  border-color: var(--primary);
-}
-
-/* Style of the inner "Choose File" button (modern browsers) */
-.container > input[type="file"]::file-selector-button {
-  background: var(--primary);
-  color: #fff;
-  border: none;
-  padding: 0.6rem 1.2rem;
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: background 0.15s ease;
-}
-
-.container > input[type="file"]::file-selector-button:hover {
-  background: var(--primary-dim);
-}
-
-/* Message under the uploader */
-.container > p {
-  text-align: center;
-  margin-top: 1.25rem;
-  font-size: 0.95rem;
-  color: var(--text-secondary);
-}
-
-/* Improve focus ring for accessibility */
-input[type="file"]:focus-visible,
-button:focus-visible {
-  outline: 3px solid color-mix(in srgb, var(--primary) 60%, transparent);
-  outline-offset: 2px;
-}
-/* Chrome, Safari, Edge 対応: スピンボタン非表示 */
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-/* Firefox 対応 */
-input[type="number"] {
-  -moz-appearance: textfield;
-}
-
-/* ---------------- Preview Modal ---------------- */
-.modal-overlay {
-  position: fixed;
+.dimension-overlay {
+  position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-}
-.modal {
-  background: var(--surface);
-  color: var(--text);
-  padding: 1rem;
-  border-radius: var(--radius);
-  max-width: 90vw;
-  max-height: 90vh;
-  overflow: auto;
-  box-shadow: var(--shadow-md);
-}
-
-.csv-preview {
-  overflow: auto;
-  max-width: 80vw;
-  max-height: 60vh;
-}
-
-.csv-preview table {
-  border-collapse: collapse;
   width: 100%;
+  height: 100%;
+  pointer-events: none;
 }
 
-.csv-preview th,
-.csv-preview td {
-  padding: 0.4rem 0.6rem;
-  border: 1px solid var(--border);
-  font-size: 0.875rem;
-  white-space: nowrap;
+.preview-empty {
+  color: var(--muted);
+  font-size: 0.95rem;
 }
 
-.csv-preview th {
-  background: var(--surface-hover);
+.viewbox-info {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
 }
 
-.modal img {
-  max-width: 80vw;
-  max-height: 80vh;
-  object-fit: contain;
+.viewbox-info div {
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.65rem;
+  background: var(--surface-elevated);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+}
+
+.viewbox-info dt {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.viewbox-info dd {
+  margin: 0.35rem 0 0;
+  font-weight: 600;
+  color: var(--text);
+}
+
+@media (min-width: 960px) {
+  .dimension-main {
+    grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+  }
+  .dimension-panel {
+    gap: 1.75rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .dimension-app {
+    padding: 1.75rem 1rem 2.5rem;
+  }
+  .card {
+    padding: 1.25rem;
+  }
+  .preview-frame {
+    padding: 1rem;
+  }
 }

--- a/usage.html
+++ b/usage.html
@@ -3,23 +3,23 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>使い方 - WebClass To-Do</title>
+  <title>使い方 - SVG Dimension Assistant</title>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9164055896922854" crossorigin="anonymous"></script>
   <!-- Use relative path so it works in production -->
   <link rel="stylesheet" href="./src/index.css" />
 </head>
 <body>
   <header style="padding: 1rem; text-align: center;">
-    <h1>📋 WebClass To-Do の使い方</h1>
+    <h1>✏️ SVG Dimension Assistant の使い方</h1>
   </header>
-  <main style="max-width: 800px; margin: auto; padding: 1rem; line-height: 1.6;">
+  <main style="max-width: 800px; margin: auto; padding: 1rem; line-height: 1.8;">
     <ol>
-      <li>WebClass から「課題実施状況一覧」を CSV 形式でダウンロードします。</li>
-      <li>トップページでその CSV ファイルを選択します。</li>
-      <li>必要に応じて期間やキーワードなどの条件を設定します。</li>
-      <li>表示された一覧を各種フォーマットでエクスポートできます。</li>
+      <li>プレビューしたい SVG のマークアップをトップページのテキストエリアに貼り付けます。</li>
+      <li>幅・高さの値を入力し、単位（px / mm）を切り替えても数値が変わらないことを確認します。</li>
+      <li>必要に応じてアスペクト比や寸法線、ラベル、丸め設定を切り替えます。</li>
+      <li>SVG 内の配色から自動的に選ばれた背景色と工業図面風の寸法線をプレビューで確認します。</li>
     </ol>
-    <p>ブラウザだけで動作するので、インストールは不要です。</p>
+    <p>設定はすべてブラウザ上で完結し、SVG ファイルを直接編集することなく寸法確認ができます。</p>
     <p><a href="index.html">トップへ戻る</a></p>
   </main>
 </body>


### PR DESCRIPTION
## Summary
- replace the previous to-do UI with an SVG dimension assistant that parses markup, preserves numeric values when units change, and exposes the requested default toggles
- derive a neutral background colour from SVG fills/strokes, render industrial-format dimension arrows with optional labels, and refresh the layout styling to match the new tool
- update documentation and usage guidance to reflect the new functionality and simplify runtime dependencies

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f65f3c883c8326bf7f8935cdb051a4