### PR TITLE
Add direct iPhone Reminders bulk add modal

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -579,3 +579,135 @@ input[type="number"] {
   max-height: 80vh;
   object-fit: contain;
 }
+
+.reminder-modal {
+  width: min(640px, 90vw);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.reminder-modal h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.reminder-modal__description {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.reminder-modal__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.reminder-modal__section h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.reminder-modal__sort-fields,
+.reminder-modal__sort-order {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.reminder-modal__radio {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.reminder-modal__status-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.reminder-modal__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface-hover);
+  cursor: pointer;
+  transition: background 0.2s ease, border 0.2s ease, color 0.2s ease;
+}
+
+.reminder-modal__status input {
+  accent-color: var(--primary);
+}
+
+.reminder-modal__status.is-selected {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+}
+
+.reminder-modal__preview {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-hover);
+  max-height: 260px;
+  overflow: auto;
+  padding: 0.5rem;
+}
+
+.reminder-modal__preview ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.reminder-modal__preview li + li {
+  border-top: 1px solid var(--border);
+}
+
+.reminder-modal__preview li {
+  padding: 0.4rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.reminder-modal__preview-title {
+  font-weight: 600;
+}
+
+.reminder-modal__course {
+  font-weight: 400;
+  color: var(--text-secondary);
+}
+
+.reminder-modal__preview-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.reminder-modal__empty {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.reminder-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.reminder-modal__actions button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}


### PR DESCRIPTION
## Summary
- add a dedicated button that opens a Reminders sharing modal with adjustable sort options and a live preview of the filtered tasks
- preselect statuses to exclude completed items by default and share the resulting list to iPhone Reminders via the Web Share API with an iCalendar fallback
- style the modal and hook it into the existing keyboard handling so it can be dismissed with Escape

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f65d8043d0832691c8ff5a5e9ba304