### PR TITLE
Add bulk iPhone reminder export flow

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -579,3 +579,157 @@ input[type="number"] {
   max-height: 80vh;
   object-fit: contain;
 }
+
+/* ---------------- Reminder modal ---------------- */
+.reminder-modal {
+  max-width: 720px;
+}
+
+.reminder-modal h2 {
+  margin-top: 0;
+}
+
+.reminder-intro {
+  margin-bottom: 1rem;
+  font-size: 0.95rem;
+}
+
+.reminder-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.reminder-field h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.reminder-field-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.reminder-status-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.reminder-status-actions button {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.75rem;
+}
+
+.reminder-status-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.75rem;
+  background: var(--surface-hover);
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+.reminder-status-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.reminder-status-empty {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.reminder-sort-controls {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.sort-toggle {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+}
+
+.sort-toggle:hover {
+  background: var(--surface-hover);
+}
+
+.reminder-preview {
+  margin-top: 1rem;
+}
+
+.reminder-preview-list {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-hover);
+  max-height: 240px;
+  overflow-y: auto;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.reminder-preview-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.reminder-preview-title {
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.reminder-preview-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.reminder-empty {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.reminder-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.reminder-hint {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin-top: 1rem;
+}
+
+@media (max-width: 599px) {
+  .reminder-modal {
+    width: 90vw;
+    padding: 1rem;
+  }
+
+  .reminder-status-actions button {
+    font-size: 0.7rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reminder export button that opens a bulk-send modal with adjustable status and sort conditions
- exclude completed statuses by default in the reminder modal and show a live preview of the tasks to be sent
- build an ICS-based export so iOS Reminders can receive the filtered tasks directly via Web Share or file fallback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f65d8043d0832691c8ff5a5e9ba304