### PR TITLE
Add SVG background removal and recolor tools

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -579,3 +579,166 @@ input[type="number"] {
   max-height: 80vh;
   object-fit: contain;
 }
+
+/* ---------------- SVG tools ---------------- */
+.svg-tools {
+  width: min(960px, 100%);
+  margin: 3rem auto;
+  padding: 1.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.svg-tools h2 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+.svg-tools p {
+  margin: 0 0 1.5rem 0;
+  color: var(--text-secondary);
+}
+
+.svg-tools-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.svg-tools-options {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1rem;
+}
+
+.svg-tools-options label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.svg-tools-options input[type="color"] {
+  width: 3rem;
+  height: 2rem;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: none;
+}
+
+.svg-tools-color-value {
+  font-family: "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.svg-tools-file-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.svg-tools-file-row input[type="file"] {
+  max-width: 320px;
+}
+
+.svg-tools-file-row input[type="file"]::file-selector-button {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.svg-tools-file-row input[type="file"]::file-selector-button:hover {
+  background: var(--primary-dim);
+}
+
+.svg-tools-action-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.svg-tools-textareas {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 900px) {
+  .svg-tools-textareas {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .svg-tools-file-row {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.svg-tools textarea {
+  width: 100%;
+  min-height: 220px;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--surface-hover);
+  color: var(--text);
+  font-family: "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  padding: 0.75rem;
+  resize: vertical;
+}
+
+.svg-tools textarea:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.svg-tools-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.svg-tools-status {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.svg-tools-preview {
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px dashed var(--border);
+  border-radius: 0.75rem;
+  min-height: 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface-hover);
+}
+
+.svg-tools-preview svg {
+  max-width: 100%;
+  max-height: 260px;
+}
+
+.svg-tools-empty-preview {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.svg-tools-error {
+  margin-top: 1rem;
+  color: #d14343;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- add an SVG utility section that can strip canvas-sized background rectangles and recolor shapes in uploaded or pasted markup
- provide controls for toggling operations, previewing results, and downloading the processed SVG
- style the new SVG tool card so it matches the existing theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f8c975fbb08326b76dcad451db3c50