### PR TITLE
Add SVG editing tools for background removal and recoloring

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from "uuid";
 import { createEvents } from "ics";
 // import domtoimage from 'dom-to-image';
 import html2canvas from "html2canvas";
+import SvgTools from "./components/SvgTools";
 
 const TODAY = DateTime.local().toISODate(); // 例: "2025-07-19"
 const DEFAULT_SPAN_DAYS = 7; // 期間
@@ -911,9 +912,11 @@ export default function App() {
             </main>
           </>
         )}
-      </div>
-      {preview && (
-        <div className="modal-overlay" onClick={closePreview}>
+
+      <SvgTools />
+    </div>
+    {preview && (
+      <div className="modal-overlay" onClick={closePreview}>
           <div className="modal" onClick={(e) => e.stopPropagation()}>
             {preview.mime.startsWith("image/") ? (
               <img

--- a/src/components/SvgTools.jsx
+++ b/src/components/SvgTools.jsx
@@ -1,0 +1,415 @@
+import React, { useCallback, useRef, useState } from "react";
+
+const SVG_SHAPE_SELECTOR =
+  "path, rect, circle, ellipse, polygon, polyline, line, use, g";
+
+const parseNumeric = (value) => {
+  if (value == null) return Number.NaN;
+  if (typeof value === "number") return value;
+  const trimmed = value.trim();
+  if (!trimmed) return Number.NaN;
+  const num = parseFloat(trimmed);
+  return Number.isFinite(num) ? num : Number.NaN;
+};
+
+const getSvgMetrics = (svgEl) => {
+  const metrics = {
+    width: Number.NaN,
+    height: Number.NaN,
+    minX: 0,
+    minY: 0,
+  };
+
+  const widthAttr = svgEl.getAttribute("width");
+  const heightAttr = svgEl.getAttribute("height");
+  const width = parseNumeric(widthAttr);
+  const height = parseNumeric(heightAttr);
+  if (Number.isFinite(width)) metrics.width = width;
+  if (Number.isFinite(height)) metrics.height = height;
+
+  const viewBoxAttr = svgEl.getAttribute("viewBox");
+  if (viewBoxAttr) {
+    const parts = viewBoxAttr
+      .replace(/,/g, " ")
+      .split(/\s+/)
+      .filter(Boolean)
+      .map(Number);
+    if (parts.length === 4 && parts.every((n) => Number.isFinite(n))) {
+      const [minX, minY, vbWidth, vbHeight] = parts;
+      metrics.minX = minX;
+      metrics.minY = minY;
+      if (!Number.isFinite(metrics.width)) metrics.width = vbWidth;
+      if (!Number.isFinite(metrics.height)) metrics.height = vbHeight;
+    }
+  }
+
+  const vb = svgEl.viewBox?.baseVal;
+  if (vb) {
+    metrics.minX = vb.x;
+    metrics.minY = vb.y;
+    if (!Number.isFinite(metrics.width)) metrics.width = vb.width;
+    if (!Number.isFinite(metrics.height)) metrics.height = vb.height;
+  }
+
+  return metrics;
+};
+
+const approxEqual = (a, b, tolerance) => Math.abs(a - b) <= tolerance;
+
+const matchesDimension = (attr, expected, tolerance) => {
+  if (!Number.isFinite(expected)) return false;
+  if (!attr) return false;
+  const value = attr.trim();
+  if (!value) return false;
+  if (value.endsWith("%")) {
+    const percentage = parseFloat(value);
+    return Number.isFinite(percentage) && Math.abs(percentage - 100) < 0.01;
+  }
+  const numeric = parseNumeric(value);
+  if (!Number.isFinite(numeric)) return false;
+  return approxEqual(numeric, expected, tolerance);
+};
+
+const matchesPosition = (attr, expected, tolerance) => {
+  if (!attr) return approxEqual(0, expected, tolerance);
+  const value = attr.trim();
+  if (!value) return approxEqual(0, expected, tolerance);
+  if (value.endsWith("%")) {
+    const percentage = parseFloat(value);
+    return Number.isFinite(percentage) && Math.abs(percentage) < 0.01;
+  }
+  const numeric = parseNumeric(value);
+  if (!Number.isFinite(numeric)) return false;
+  return approxEqual(numeric, expected, tolerance);
+};
+
+const removeCanvasSizedShapes = (svgEl, metrics) => {
+  const { width, height, minX, minY } = metrics;
+  if (!Number.isFinite(width) || !Number.isFinite(height)) return;
+  const tolerance = Math.max(width, height) * 0.005 + 0.5;
+
+  const candidates = svgEl.querySelectorAll(
+    "rect, path, polygon, polyline, circle, ellipse, g, use",
+  );
+
+  candidates.forEach((node) => {
+    if (node.closest("defs")) return;
+
+    if (node.tagName.toLowerCase() === "rect") {
+      const widthAttr = node.getAttribute("width");
+      const heightAttr = node.getAttribute("height");
+      const xAttr = node.getAttribute("x");
+      const yAttr = node.getAttribute("y");
+      if (
+        matchesDimension(widthAttr, width, tolerance) &&
+        matchesDimension(heightAttr, height, tolerance) &&
+        matchesPosition(xAttr, minX, tolerance) &&
+        matchesPosition(yAttr, minY, tolerance)
+      ) {
+        node.remove();
+        return;
+      }
+    }
+
+    const getBBox = node.getBBox;
+    if (typeof getBBox === "function") {
+      try {
+        const box = getBBox.call(node);
+        if (
+          approxEqual(box.width, width, tolerance) &&
+          approxEqual(box.height, height, tolerance) &&
+          approxEqual(box.x, minX, tolerance) &&
+          approxEqual(box.y, minY, tolerance)
+        ) {
+          node.remove();
+        }
+      } catch (error) {
+        // ignore rendering errors when computing BBox
+      }
+    }
+  });
+};
+
+const applyFillColor = (svgEl, fillColor) => {
+  if (!fillColor) return;
+  const shapes = svgEl.querySelectorAll(SVG_SHAPE_SELECTOR);
+  shapes.forEach((node) => {
+    if (node.closest("defs")) return;
+    const current = (node.getAttribute("fill") || "").trim().toLowerCase();
+    const styleFill = node.style?.fill?.toLowerCase();
+    if (current === "none" || styleFill === "none") return;
+    node.setAttribute("fill", fillColor);
+    if (node.style) {
+      node.style.fill = fillColor;
+    }
+  });
+};
+
+const serializeSvg = (svgEl) => {
+  const serializer = new XMLSerializer();
+  return serializer.serializeToString(svgEl);
+};
+
+const ensureNamespace = (svgEl) => {
+  if (!svgEl.getAttribute("xmlns")) {
+    svgEl.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+  }
+  if (!svgEl.getAttribute("xmlns:xlink")) {
+    svgEl.setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
+  }
+};
+
+export default function SvgTools() {
+  const [svgSource, setSvgSource] = useState("");
+  const [processedSvg, setProcessedSvg] = useState("");
+  const [removeBackground, setRemoveBackground] = useState(false);
+  const [changeFill, setChangeFill] = useState(true);
+  const [fillColor, setFillColor] = useState("#3b82f6");
+  const [colorPickerValue, setColorPickerValue] = useState("#3b82f6");
+  const [error, setError] = useState("");
+  const [fileName, setFileName] = useState("");
+  const fileInputRef = useRef(null);
+
+  const processSvgContent = useCallback(
+    (source, options) => {
+      if (!source || !source.trim()) {
+        setProcessedSvg("");
+        setError("");
+        return;
+      }
+
+      try {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(source, "image/svg+xml");
+        const parserError = doc.querySelector("parsererror");
+        if (parserError) {
+          throw new Error(
+            parserError.textContent?.replace(/\s+/g, " ") ||
+              "SVG を解析できませんでした",
+          );
+        }
+
+        const svgEl = doc.querySelector("svg");
+        if (!svgEl) {
+          throw new Error("SVG 要素が見つかりません");
+        }
+
+        ensureNamespace(svgEl);
+
+        const metrics = getSvgMetrics(svgEl);
+        if (options.removeBackground) {
+          removeCanvasSizedShapes(svgEl, metrics);
+        }
+        if (options.changeFill) {
+          applyFillColor(svgEl, options.fillColor);
+        }
+
+        const serialized = serializeSvg(svgEl);
+        setProcessedSvg(serialized);
+        setError("");
+      } catch (err) {
+        console.error("Failed to process SVG", err);
+        setProcessedSvg("");
+        setError(err.message || "SVG の処理に失敗しました");
+      }
+    },
+    [setProcessedSvg, setError],
+  );
+
+  const handleApply = useCallback(() => {
+    processSvgContent(svgSource, {
+      removeBackground,
+      changeFill,
+      fillColor,
+    });
+  }, [processSvgContent, svgSource, removeBackground, changeFill, fillColor]);
+
+  const handleFileChange = (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setFileName(file.name);
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const text = String(e.target?.result || "");
+      setSvgSource(text);
+      processSvgContent(text, {
+        removeBackground,
+        changeFill,
+        fillColor,
+      });
+    };
+    reader.onerror = () => {
+      setError("ファイルの読み込みに失敗しました");
+    };
+    reader.readAsText(file, "utf-8");
+  };
+
+  const handleRemoveBackgroundChange = (event) => {
+    const next = event.target.checked;
+    setRemoveBackground(next);
+    if (svgSource.trim()) {
+      processSvgContent(svgSource, { changeFill, fillColor, removeBackground: next });
+    }
+  };
+
+  const handleChangeFillToggle = (event) => {
+    const next = event.target.checked;
+    setChangeFill(next);
+    if (svgSource.trim()) {
+      processSvgContent(svgSource, { removeBackground, changeFill: next, fillColor });
+    }
+  };
+
+  const handleColorChange = (event) => {
+    const { value, type } = event.target;
+    if (type === "color") {
+      setColorPickerValue(value);
+      setFillColor(value);
+      if (svgSource.trim() && changeFill) {
+        processSvgContent(svgSource, {
+          removeBackground,
+          changeFill,
+          fillColor: value,
+        });
+      }
+      return;
+    }
+
+    setFillColor(value);
+    if (/^#[0-9a-fA-F]{6}$/.test(value)) {
+      setColorPickerValue(value);
+    }
+    if (svgSource.trim() && changeFill) {
+      processSvgContent(svgSource, {
+        removeBackground,
+        changeFill,
+        fillColor: value,
+      });
+    }
+  };
+
+  const handleTextAreaChange = (event) => {
+    setSvgSource(event.target.value);
+  };
+
+  const handleReset = () => {
+    setSvgSource("");
+    setProcessedSvg("");
+    setFileName("");
+    setFillColor("#3b82f6");
+    setColorPickerValue("#3b82f6");
+    setError("");
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const handleDownload = () => {
+    if (!processedSvg) return;
+    const blob = new Blob([processedSvg], { type: "image/svg+xml" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = fileName ? fileName.replace(/\.svg$/i, "_processed.svg") : "processed.svg";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <section className="svg-tools" aria-labelledby="svg-tools-heading">
+      <div className="svg-tools__header">
+        <h2 id="svg-tools-heading">🖼️ SVG ツール</h2>
+        <p>
+          SVG の背景を取り除いたり、塗りつぶし色を一括で変更したりできます。ファイルを選ぶか、直接 SVG
+          コードを貼り付けてください。
+        </p>
+      </div>
+
+      <div className="svg-tools__inputs">
+        <div className="svg-tools__file">
+          <label className="svg-tools__label" htmlFor="svgUpload">
+            SVG ファイルを選択
+          </label>
+          <input
+            ref={fileInputRef}
+            id="svgUpload"
+            type="file"
+            accept=".svg"
+            onChange={handleFileChange}
+          />
+          {fileName && <span className="svg-tools__file-name">{fileName}</span>}
+        </div>
+        <textarea
+          placeholder="ここに SVG コードを貼り付けてください"
+          value={svgSource}
+          onChange={handleTextAreaChange}
+          spellCheck={false}
+        />
+      </div>
+
+      <div className="svg-tools__controls">
+        <label className="svg-tools__checkbox">
+          <input
+            type="checkbox"
+            checked={removeBackground}
+            onChange={handleRemoveBackgroundChange}
+          />
+          キャンバスと同じサイズの図形を削除
+        </label>
+        <label className="svg-tools__checkbox">
+          <input type="checkbox" checked={changeFill} onChange={handleChangeFillToggle} />
+          塗りつぶし色を変更
+        </label>
+        <div className="svg-tools__color" aria-hidden={!changeFill}>
+          <label htmlFor="svgFillColor">塗りつぶし色</label>
+          <input
+            id="svgFillColor"
+            type="color"
+            value={colorPickerValue}
+            onChange={handleColorChange}
+            disabled={!changeFill}
+            aria-disabled={!changeFill}
+          />
+          <input
+            type="text"
+            value={fillColor}
+            onChange={handleColorChange}
+            disabled={!changeFill}
+            aria-label="塗りつぶし色 (CSS カラー形式)"
+          />
+        </div>
+        <div className="svg-tools__actions">
+          <button type="button" onClick={handleApply}>
+            SVG を変換
+          </button>
+          <button type="button" onClick={handleReset}>
+            クリア
+          </button>
+        </div>
+      </div>
+
+      {error && <div className="svg-tools__error">{error}</div>}
+
+      {processedSvg && (
+        <div className="svg-tools__result">
+          <div>
+            <h3>プレビュー</h3>
+            <div
+              className="svg-tools__preview"
+              dangerouslySetInnerHTML={{ __html: processedSvg }}
+            />
+          </div>
+          <div className="svg-tools__output">
+            <h3>変換後の SVG</h3>
+            <textarea value={processedSvg} readOnly spellCheck={false} />
+            <button type="button" onClick={handleDownload}>
+              SVG をダウンロード
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -530,6 +530,165 @@ input[type="number"] {
   -moz-appearance: textfield;
 }
 
+/* ---------------- SVG Tools ---------------- */
+.svg-tools {
+  grid-column: 1 / -1;
+  margin-top: var(--gap);
+  padding: var(--gap);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.svg-tools__header h2 {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: clamp(1.2rem, 2vw + 0.8rem, 1.5rem);
+}
+
+.svg-tools__header p {
+  margin: 0.5rem 0 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.svg-tools__inputs {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.svg-tools__file {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.svg-tools__file input[type="file"] {
+  font-size: 0.95rem;
+}
+
+.svg-tools__file-name {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.svg-tools textarea {
+  width: 100%;
+  min-height: 160px;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  font-size: 0.9rem;
+  background: var(--surface);
+  color: var(--text);
+  resize: vertical;
+}
+
+.svg-tools textarea:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--primary) 65%, transparent);
+  outline-offset: 2px;
+}
+
+.svg-tools__controls {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.svg-tools__checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.svg-tools__color {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.svg-tools__color input[type="text"] {
+  width: 7rem;
+  padding: 0.45rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--surface);
+  color: var(--text);
+  font-family: inherit;
+}
+
+.svg-tools__actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+.svg-tools__error {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius);
+  background: rgba(248, 113, 113, 0.15);
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.svg-tools__result {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.svg-tools__preview {
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-hover);
+  min-height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  overflow: auto;
+}
+
+.svg-tools__preview svg {
+  max-width: 100%;
+  height: auto;
+}
+
+.svg-tools__output textarea {
+  min-height: 200px;
+  background: var(--surface-hover);
+}
+
+.svg-tools__output button {
+  margin-top: 0.75rem;
+}
+
+@media (min-width: 768px) {
+  .svg-tools__result {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .svg-tools__error {
+    background: rgba(248, 113, 113, 0.25);
+    color: #fca5a5;
+  }
+}
+
 /* ---------------- Preview Modal ---------------- */
 .modal-overlay {
   position: fixed;


### PR DESCRIPTION
## Summary
- add a new SvgTools panel that parses uploaded SVGs and optionally strips full-canvas background shapes
- allow recoloring of fills across shapes and present a preview plus download of the processed SVG
- mount the SVG tooling in the app layout and style the new section for consistency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f8c975fbb08326b76dcad451db3c50