### PR TITLE
Add reminder shortcut link to usage guide

### DIFF
--- a/usage.html
+++ b/usage.html
@@ -56,6 +56,15 @@
         <li><strong>📲 リマインダーに追加</strong>：iPhone / iPad の Safari から利用すると、専用ショートカットを介して Apple のリマインダーへ送信できます（ステータスが「合格」「回答済み」の課題は除外されます）。</li>
       </ul>
       <p>
+        リマインダー連携を初めて使う場合は、事前に
+        <a
+          href="https://www.icloud.com/shortcuts/fdadcf1171ad4a8a82f7b2d6f494a57f"
+          target="_blank"
+          rel="noopener"
+          >「WebClass Reminders」ショートカット</a
+        >を追加しておいてください。
+      </p>
+      <p>
         書き出し時には内容のプレビューが表示され、「ダウンロード」ボタンを押すと保存されます。
         プレビューを閉じるときは右上の「閉じる」ボタンか <kbd>Esc</kbd> キーを押してください。
       </p>


### PR DESCRIPTION
## Summary
- add a prominent link to install the WebClass Reminders shortcut in the usage guide

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb82f50ed48326b691b2a0f017aa2a